### PR TITLE
Use rd.conf Tuning/TempDirectory as RDTempDir result when available

### DIFF
--- a/lib/rdconf.cpp
+++ b/lib/rdconf.cpp
@@ -968,6 +968,10 @@ QString RDHomeDir()
 
 QString RDTempDir()
 {
+  QString conf_temp_directory = RDConfiguration()->tempDirectory();
+  if (conf_temp_directory != NULL) {
+    return conf_temp_directory;
+  }
 #ifdef WIN32
   if(getenv("TEMP")!=NULL) {
     return QString(getenv("TEMP"));

--- a/lib/rdconfig.cpp
+++ b/lib/rdconfig.cpp
@@ -354,6 +354,11 @@ int RDConfig::realtimePriority()
   return conf_realtime_priority;
 }
 
+// Don't use this method in application code, use RDTempDirectory()
+QString RDConfig::tempDirectory()
+{
+  return conf_temp_directory;
+}
 
 QString RDConfig::sasStation() const
 {
@@ -485,6 +490,7 @@ void RDConfig::load()
   conf_enable_mixer_logging=profile->boolValue("Caed","EnableMixerLogging");
   conf_use_realtime=profile->boolValue("Tuning","UseRealtime",false);
   conf_realtime_priority=profile->intValue("Tuning","RealtimePriority",9);
+  conf_temp_directory=profile->stringValue("Tuning","TempDirectory",NULL);
   conf_sas_station=profile->stringValue("SASFilter","Station","");
   conf_sas_matrix=profile->intValue("SASFilter","Matrix",0);
   conf_sas_base_cart=profile->intValue("SASFilter","BaseCart",0);
@@ -554,6 +560,7 @@ void RDConfig::clear()
   conf_enable_mixer_logging=false;
   conf_use_realtime=false;
   conf_realtime_priority=9;
+  conf_temp_directory=NULL;
   conf_sas_station="";
   conf_sas_matrix=-1;
   conf_sas_base_cart=1;

--- a/lib/rdconfig.h
+++ b/lib/rdconfig.h
@@ -97,6 +97,7 @@ class RDConfig
 #endif
   bool useRealtime();
   int realtimePriority();
+  QString tempDirectory();
   QString sasStation() const;
   int sasMatrix() const;
   unsigned sasBaseCart() const;
@@ -148,6 +149,7 @@ class RDConfig
   bool conf_enable_mixer_logging;
   bool conf_use_realtime;
   int conf_realtime_priority;
+  QString conf_temp_directory;
   QString conf_sas_station;
   int conf_sas_matrix;
   unsigned conf_sas_base_cart;


### PR DESCRIPTION
Provides an alternate solution to configure temp directory used by Rivendell (import, convertion, ripping, etc).

A TempDirectory  entry (in Tuning section) into /etc/rd.conf :

```
[Tuning]
TempDirectory=/var/tmp
```
