### PR TITLE
Update edit_cart.cpp

### DIFF
--- a/rdlibrary/edit_cart.cpp
+++ b/rdlibrary/edit_cart.cpp
@@ -815,7 +815,7 @@ void EditCart::okData()
     if(!system->allowDuplicateCartTitles()) {
       sql=QString("select NUMBER from CART where ")+
 	"(TITLE=\""+RDEscapeString(rdcart_controls.title_edit->text())+"\") &&"+
-	QString().sprintf("(NUMBER=%u)",rdcart_cart->number());
+	QString().sprintf("(NUMBER!=%u)",rdcart_cart->number());
       q=new RDSqlQuery(sql);
       if(q->first()) {
 	QMessageBox::warning(this,tr("Duplicate Title"),


### PR DESCRIPTION
Allow for saving of edited cart when duplicate cart titles are NOT allowed;  Without this fix, it is impossible to edit existing carts when the global configuration does not permit duplicate cart names.
