### PR TITLE
Prevent Xport::AddCart() to create Cart Group

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -14480,3 +14480,6 @@
 2014-09-18 Fred Gleason <fredg@paravelsystems.com>
 	* Merged patch from albanpeignier to allow [Tuning] entry in
 	rd.conf(5) to specify temporary directory [GitHub Issue #000011].
+2014-09-19 Alban Peignier <alban@tryphon.eu>
+	* Fixed 'web/rdxport/carts.cpp' which tried to create associated group
+	during cart creation

--- a/web/rdxport/carts.cpp
+++ b/web/rdxport/carts.cpp
@@ -73,7 +73,7 @@ void Xport::AddCart()
   if(!xport_user->groupAuthorized(group_name)) {
     XmlExit("No such group",404);
   }
-  group=new RDGroup(group_name,this);
+  group=new RDGroup(group_name);
   if(cart_number==0) {
     if((cart_number=group->nextFreeCart())==0) {
       delete group;


### PR DESCRIPTION
`Xport::AddCart()` tries to create Group .. which should already exist.

But I don't why `this` is used as second argument.
