### PR TITLE
Empty QString instead of NULL for RdConfig->tempDirectory()

### DIFF
--- a/lib/rdconf.cpp
+++ b/lib/rdconf.cpp
@@ -969,7 +969,7 @@ QString RDHomeDir()
 QString RDTempDir()
 {
   QString conf_temp_directory = RDConfiguration()->tempDirectory();
-  if (conf_temp_directory != NULL) {
+  if (!conf_temp_directory.isEmpty()) {
     return conf_temp_directory;
   }
 #ifdef WIN32

--- a/lib/rdconfig.cpp
+++ b/lib/rdconfig.cpp
@@ -490,7 +490,7 @@ void RDConfig::load()
   conf_enable_mixer_logging=profile->boolValue("Caed","EnableMixerLogging");
   conf_use_realtime=profile->boolValue("Tuning","UseRealtime",false);
   conf_realtime_priority=profile->intValue("Tuning","RealtimePriority",9);
-  conf_temp_directory=profile->stringValue("Tuning","TempDirectory",NULL);
+  conf_temp_directory=profile->stringValue("Tuning","TempDirectory","");
   conf_sas_station=profile->stringValue("SASFilter","Station","");
   conf_sas_matrix=profile->intValue("SASFilter","Matrix",0);
   conf_sas_base_cart=profile->intValue("SASFilter","BaseCart",0);
@@ -560,7 +560,7 @@ void RDConfig::clear()
   conf_enable_mixer_logging=false;
   conf_use_realtime=false;
   conf_realtime_priority=9;
-  conf_temp_directory=NULL;
+  conf_temp_directory="";
   conf_sas_station="";
   conf_sas_matrix=-1;
   conf_sas_base_cart=1;


### PR DESCRIPTION
Use an empty QString (instead of NULL) when `RdConfig->tempDirectory()` isn't defined. 

`conf_temp_directory=NULL` seems to be a bad idea for a QString.
