### PR TITLE
Fixes 'Next Timed Start [nn:nn:nn]' encoding

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -14480,3 +14480,5 @@
 2014-09-18 Fred Gleason <fredg@paravelsystems.com>
 	* Merged patch from albanpeignier to allow [Tuning] entry in
 	rd.conf(5) to specify temporary directory [GitHub Issue #000011].
+2014-09-20 Alban Peignier <alban@tryphon.eu>
+	* Fixes 'Next Timed Start: [nn:nn:nn]' encoding in RdAirPlay

--- a/rdairplay/post_counter.cpp
+++ b/rdairplay/post_counter.cpp
@@ -138,9 +138,8 @@ void PostCounter::UpdateDisplay()
   }
 
   if(isEnabled()&&(!post_time.isNull())) {
-    str=QString(tr("Next Timed Start"));
-    point=QString().sprintf("%s [%s]",(const char *)str,
-			    (const char *)post_time.toString(post_time_format));
+    point= trUtf8("Next Timed Start") + " [" + post_time.toString(post_time_format) + "]";
+
     if(post_offset_valid) {
       if(offset<-POST_COUNTER_MARGIN) {
 	state=QString().sprintf("-%s",(const char *)


### PR DESCRIPTION
Replace QString.sprintf by concatenations to preserve encoding 'Next Timed Start (and french accents).

**Before**

![before](https://cloud.githubusercontent.com/assets/24570/4345427/67796912-40cd-11e4-9c47-7d279a43d482.png)

**After**

![with](https://cloud.githubusercontent.com/assets/24570/4345428/77725360-40cd-11e4-81c7-8ecf420b6d85.png)
