### PR TITLE
Ensures utf8 in rdxport responses, as announced by the xml encoding

### DIFF
--- a/web/rdxport/carts.cpp
+++ b/web/rdxport/carts.cpp
@@ -106,7 +106,7 @@ void Xport::AddCart()
   printf("<?xml version=\"1.0\" encoding=\"UTF-8\" ?>\n");
   printf("<cartAdd>\n");
   if(cart->exists()) {
-    printf("%s",(const char *)cart->xml(false));
+    printf("%s",(const char *)cart->xml(false).utf8());
   }
   delete cart;
   printf("</cartAdd>\n");
@@ -175,7 +175,7 @@ void Xport::ListCarts()
   printf("<cartList>\n");
   while(q->next()) {
     cart=new RDCart(q->value(0).toUInt());
-    printf("%s",(const char *)cart->xml(include_cuts));
+    printf("%s",(const char *)cart->xml(include_cuts).utf8());
     delete cart;
   }
   printf("</cartList>\n");
@@ -217,7 +217,7 @@ void Xport::ListCart()
   printf("<?xml version=\"1.0\" encoding=\"UTF-8\" ?>\n");
   printf("<cartList>\n");
   cart=new RDCart(cart_number);
-  printf("%s",(const char *)cart->xml(include_cuts));
+  printf("%s",(const char *)cart->xml(include_cuts).utf8());
   delete cart;
   printf("</cartList>\n");
 
@@ -378,7 +378,7 @@ void Xport::EditCart()
   printf("Status: 200\n\n");
   printf("<?xml version=\"1.0\" encoding=\"UTF-8\" ?>\n");
   printf("<cartList>\n");
-  printf("%s",(const char *)cart->xml(include_cuts));
+  printf("%s",(const char *)cart->xml(include_cuts).utf8());
   delete cart;
   printf("</cartList>\n");
 
@@ -467,7 +467,7 @@ void Xport::AddCut()
   printf("<cutAdd>\n");
   cut=new RDCut(cart_number,cut_number);
   if(cut->exists()) {
-    printf("%s",(const char *)cut->xml());
+    printf("%s",(const char *)cut->xml().utf8());
   }
   delete cut;
   delete cart;
@@ -512,7 +512,7 @@ void Xport::ListCuts()
   while(q->next()) {
     cut=new RDCut(q->value(0).toString());
     if(cut->exists()) {
-      printf("%s",(const char *)cut->xml());
+      printf("%s",(const char *)cut->xml().utf8());
     }
     delete cut;
   }
@@ -558,7 +558,7 @@ void Xport::ListCut()
   printf("Status: 200\n\n");
   printf("<?xml version=\"1.0\" encoding=\"UTF-8\" ?>\n");
   printf("<cutList>\n");
-  printf("%s",(const char *)cut->xml());
+  printf("%s",(const char *)cut->xml().utf8());
   printf("</cutList>\n");
   delete cut;
 

--- a/web/rdxport/groups.cpp
+++ b/web/rdxport/groups.cpp
@@ -58,7 +58,7 @@ void Xport::ListGroups()
   printf("<groupList>\n");
   while(q->next()) {
     group=new RDGroup(q->value(0).toString());
-    printf("%s",(const char *)group->xml());
+    printf("%s",(const char *)group->xml().utf8());
     delete group;
   }
   printf("</groupList>\n");
@@ -102,7 +102,7 @@ void Xport::ListGroup()
   printf("Status: 200\n\n");
   printf("<?xml version=\"1.0\" encoding=\"UTF-8\" ?>\n");
   group=new RDGroup(q->value(0).toString());
-  printf("%s",(const char *)group->xml());
+  printf("%s",(const char *)group->xml().utf8());
   delete group;
 
   delete q;

--- a/web/rdxport/logs.cpp
+++ b/web/rdxport/logs.cpp
@@ -76,7 +76,7 @@ void Xport::ListLogs()
   printf("<logList>\n");
   while(q->next()) {
     log=new RDLog(q->value(0).toString());
-    printf("%s",(const char *)log->xml());
+    printf("%s",(const char *)log->xml().utf8());
     delete log;
   }
   printf("</logList>\n");
@@ -117,7 +117,7 @@ void Xport::ListLog()
   printf("Content-type: application/xml\n");
   printf("Status: 200\n\n");
   printf("<?xml version=\"1.0\" encoding=\"UTF-8\" ?>\n");
-  printf("%s\n",(const char *)log_event->xml());
+  printf("%s\n",(const char *)log_event->xml().utf8());
 
   Exit(0);
 }

--- a/web/rdxport/services.cpp
+++ b/web/rdxport/services.cpp
@@ -67,7 +67,7 @@ void Xport::ListServices()
   printf("<serviceList>\n");
   while(q->next()) {
     svc=new RDSvc(q->value(0).toString());
-    printf("%s",(const char *)svc->xml());
+    printf("%s",(const char *)svc->xml().utf8());
     delete svc;
   }
   printf("</serviceList>\n");


### PR DESCRIPTION
For the moment, `rdxport` includes no-utf8 strings in XML responses. The responses are invalid for most API tools.

**Before**

```
<title>Test de caract�res : &quot;&apos;��</title>
```

**After**

```
<title>Test de caractères : &quot;&apos;éà</title>
```
