### PR TITLE
Implement "holdover events"

### DIFF
--- a/lib/rdlog_event.cpp
+++ b/lib/rdlog_event.cpp
@@ -626,20 +626,22 @@ void RDLogEvent::setLogLine(int line,RDLogLine *ll)
 }
 
 
-RDLogLine *RDLogEvent::loglineById(int id) const
+RDLogLine *RDLogEvent::loglineById(int id, bool ignore_holdovers) const
 {
-  for(int i=0;i<size();i++) {
-    if(log_line[i]->id()==id) {
-      return log_line[i];
-    }
-  }
-  return NULL;
+  int line = lineById(id, ignore_holdovers);
+  if(line == -1)
+    return NULL;
+  else
+    return log_line[line];
 }
 
 
-int RDLogEvent::lineById(int id) const
+int RDLogEvent::lineById(int id, bool ignore_holdovers) const
 {
   for(int i=0;i<size();i++) {
+    if(ignore_holdovers && log_line[i]->isHoldover()) {
+      continue;
+    }    
     if(log_line[i]->id()==id) {
       return i;
     }

--- a/lib/rdlog_event.h
+++ b/lib/rdlog_event.h
@@ -61,8 +61,8 @@ class RDLogEvent
    QTime blockStartTime(int line);
    RDLogLine *logLine(int line) const;
    void setLogLine(int line,RDLogLine *ll);
-   RDLogLine *loglineById(int id) const;
-   int lineById(int id) const;
+   RDLogLine *loglineById(int id, bool ignore_holdovers=false) const;
+   int lineById(int id, bool ignore_holdovers=false) const;
    int lineByStartHour(int hour,RDLogLine::StartTimeType type) const;
    int lineByStartHour(int hour) const;
    int nextTimeStart(QTime after);

--- a/lib/rdlog_line.cpp
+++ b/lib/rdlog_line.cpp
@@ -174,6 +174,7 @@ void RDLogLine::clear()
   log_link_id=-1;
   log_link_embedded=false;
   log_start_source=RDLogLine::StartUnknown;
+  is_holdover = false;
 }
 
 
@@ -2092,4 +2093,14 @@ QString RDLogLine::sourceText(RDLogLine::Source src)
 	return QObject::tr("Tracker");
   }
   return QObject::tr("Unknown");
+}
+
+bool RDLogLine::isHoldover() const
+{
+  return is_holdover;
+}
+
+void RDLogLine::setHoldover(bool b)
+{
+  is_holdover = b;
 }

--- a/lib/rdlog_line.h
+++ b/lib/rdlog_line.h
@@ -265,6 +265,8 @@ class RDLogLine
   static QString typeText(RDLogLine::Type type);
   static QString timeTypeText(RDLogLine::TimeType type);
   static QString sourceText(RDLogLine::Source src);
+  bool isHoldover() const;
+  void setHoldover(bool);
 
  private:
   int log_id;
@@ -368,6 +370,7 @@ class RDLogLine
   int log_link_end_slop;
   int log_link_id;
   bool log_link_embedded;
+  bool is_holdover;
 };
 
 


### PR DESCRIPTION
Holdover events note those log events which are not listed in the currently loaded log but which are present because they were playing when this log was loaded.

This fixes problems arising when the duplicate IDs thus introduced cause confusion.

For more detail see: http://lists.rivendellaudio.org/pipermail/rivendell-dev/2014-March/020486.html
