### PR TITLE
Add a second scheduler code in Event import

### DIFF
--- a/lib/rdevent.cpp
+++ b/lib/rdevent.cpp
@@ -408,6 +408,17 @@ void RDEvent::setHaveCode(QString str)
   SetRow("HAVE_CODE",str,true);
 }
 
+QString RDEvent::HaveCode2()
+{
+  bool ok;
+  return GetStringValue("HAVE_CODE2",&ok);
+}
+
+
+void RDEvent::setHaveCode2(QString str)
+{
+  SetRow("HAVE_CODE2",str,true);
+}
 
 unsigned RDEvent::titleSep()
 {

--- a/lib/rdevent.h
+++ b/lib/rdevent.h
@@ -73,6 +73,8 @@ class RDEvent
   void setSchedGroup(QString str);
   QString HaveCode();
   void setHaveCode(QString str);
+  QString HaveCode2();
+  void setHaveCode2(QString str);
   unsigned titleSep();
   void setTitleSep(unsigned titlesep);
   static QString preimportTableName(const QString event_name);

--- a/lib/rdevent_line.h
+++ b/lib/rdevent_line.h
@@ -70,6 +70,8 @@ class RDEventLine
   void setSchedGroup(QString str);
   QString HaveCode() const;
   void setHaveCode(QString str);
+  QString HaveCode2() const;
+  void setHaveCode2(QString str);
   unsigned titleSep() const;
   void setTitleSep(unsigned titlesep);
   RDLogEvent *preimportCarts();
@@ -112,6 +114,7 @@ class RDEventLine
   QString event_nested_event;
   QString event_sched_group;
   QString event_have_code;
+  QString event_have_code2;
   unsigned event_title_sep;
 };
 

--- a/rdadmin/createdb.cpp
+++ b/rdadmin/createdb.cpp
@@ -8034,8 +8034,12 @@ int UpdateDb(int ver)
     delete q;
   }
 
-
-      
+  if(ver<240) {
+    sql=QString("alter table EVENTS add column ")+
+      "HAVE_CODE2 VARCHAR(10) after HAVE_CODE";
+    q=new QSqlQuery(sql);
+    delete q;
+  }
   // **** End of version updates ****
   
   //

--- a/rdlogmanager/edit_event.cpp
+++ b/rdlogmanager/edit_event.cpp
@@ -529,6 +529,23 @@ EditEvent::EditEvent(QString eventname,bool new_event,
   }
   delete q2;
 
+  // And code
+
+  event_have_code2_label=
+    new QLabel(tr("and code"),this,"event_have_code2_label");
+  event_have_code2_label->setFont(bold_font);
+  event_have_code2_label->setGeometry(CENTER_LINE+420,425,100,20);
+
+  event_have_code2_box=new QComboBox(this,"event_have_code2_box");
+  event_have_code2_box->setGeometry(CENTER_LINE+510,425,100,20);
+  event_have_code2_box->insertItem("");
+  sql2="select CODE from SCHED_CODES order by CODE";
+  q2=new RDSqlQuery(sql2);
+  while(q2->next()) {
+    event_have_code2_box->insertItem(q2->value(0).toString());
+  }
+  delete q2;
+
 
   //
   // Start Slop Time
@@ -798,6 +815,7 @@ EditEvent::EditEvent(QString eventname,bool new_event,
   }
   event_title_sep_spinbox->setValue(event_event->titleSep());
   event_have_code_box->setCurrentText(event_event->HaveCode());
+  event_have_code2_box->setCurrentText(event_event->HaveCode2());
   QColor color=event_event->color();
   if(color.isValid()) {
     event_color_button->setPalette(QPalette(color,backgroundColor()));
@@ -1070,6 +1088,8 @@ void EditEvent::importClickedData(int id)
   event_title_sep_spinbox->setEnabled(stateschedinv);
   event_have_code_box->setEnabled(stateschedinv);
   event_have_code_label->setEnabled(stateschedinv);
+  event_have_code2_box->setEnabled(stateschedinv);
+  event_have_code2_label->setEnabled(stateschedinv);
 }
 
 
@@ -1511,7 +1531,14 @@ void EditEvent::Save()
   event_event->setProperties(GetProperties());
   event_event->setSchedGroup(event_sched_group_box->currentText());  
   event_event->setTitleSep(event_title_sep_spinbox->value());
-  event_event->setHaveCode(event_have_code_box->currentText()); 
+  event_event->setHaveCode(event_have_code_box->currentText());
+  if (event_have_code_box->currentText() != QString("")) {
+    event_event->setHaveCode2(event_have_code2_box->currentText());
+  } else {
+    // save second code as first code when first code isn't defined
+    event_event->setHaveCode(event_have_code2_box->currentText());
+    event_event->setHaveCode2(QString(""));
+  }
   listname=event_name;
   listname.replace(" ","_");
   event_preimport_list->logEvent()->

--- a/rdlogmanager/edit_event.h
+++ b/rdlogmanager/edit_event.h
@@ -110,6 +110,8 @@ class EditEvent : public QDialog
   QLabel *event_title_sep_label;
   QComboBox* event_have_code_box;
   QLabel *event_have_code_label;
+  QComboBox* event_have_code2_box;
+  QLabel *event_have_code2_label;
   LibListView *event_lib_list;
   QPixmap *event_playout_map;
   QPixmap *event_macro_map;


### PR DESCRIPTION
Add a `HAVE_CODE2` in `RDEvent` to manage a selection with two scheduler codes. When the second scheduler code is defined, only carts with the two selected codes are selected. The second scheduler code rule can be broken if needed.

![rivendell-scheduler-code-2-draft-detail](https://cloud.githubusercontent.com/assets/24570/4463789/34f971c2-48ce-11e4-8d43-e206a6be7a1d.png)
