### PR TITLE
Cuts imported from a flac file have a random/null end point

### DIFF
--- a/lib/rdwavefile.cpp
+++ b/lib/rdwavefile.cpp
@@ -3759,6 +3759,8 @@ bool RDWaveFile::GetFlacStreamInfo()
   bits_per_sample=sinfo.data.stream_info.bits_per_sample;
   sample_length=sinfo.data.stream_info.total_samples;
   channels=sinfo.data.stream_info.channels;
+  ext_time_length=(unsigned)(1000.0*(double)sample_length/(double)samples_per_sec);
+  time_length=ext_time_length/1000;
   return true;
 #else
   return false;


### PR DESCRIPTION
Defines RDWaveFile ext_time_length/time_length for flac format.

**Before**

![rivendell-wavefile-fix-flac-timelength-before](https://cloud.githubusercontent.com/assets/24570/4515500/d638cbba-4bc0-11e4-83dc-2532f178f0d2.png)

**After**

![rivendell-wavefile-fix-flac-timelength](https://cloud.githubusercontent.com/assets/24570/4515501/d64504d4-4bc0-11e4-9900-9ada47127bb9.png)

Thank to Hervé from Radio Grésivaudan for the report 
