### PR TITLE
Optimize CPU usage in caed alsa playback

### DIFF
--- a/cae/cae_alsa.cpp
+++ b/cae/cae_alsa.cpp
@@ -286,249 +286,249 @@ void AlsaPlay2Callback(struct alsa_format *alsa_format)
     memset(alsa_format->card_buffer,0,alsa_format->card_buffer_size);
 
     switch(alsa_format->format) {
-	case SND_PCM_FORMAT_S16_LE:
-	  for(unsigned j=0;j<RD_MAX_STREAMS;j++) {
-	    if(alsa_playing[alsa_format->card][j]) {
-	      switch(alsa_output_channels[alsa_format->card][j]) {
-		  case 1:
-		    n=alsa_play_ring[alsa_format->card][j]->
-		      read(alsa_buffer,alsa_format->
-			   buffer_size/alsa_format->periods)/
-		      (2*sizeof(int16_t));
-		    stream_out_meter=0;  // Stream Output Meters
-		    for(int k=0;k<n;k++) {
-		      if(abs(((int16_t *)alsa_buffer)[k])>stream_out_meter) {
-			stream_out_meter=abs(((int16_t *)alsa_buffer)[k]);
-		      }
-		    }
-		    alsa_stream_output_meter[alsa_format->card][j][0]->
-		      addValue(((double)stream_out_meter)/32768.0);
-		    alsa_stream_output_meter[alsa_format->card][j][1]->
-		      addValue(((double)stream_out_meter)/32768.0);
-		    modulo=alsa_format->channels;
-		    for(unsigned i=0;i<(alsa_format->channels/2);i++) {
-		      if(alsa_output_volume[alsa_format->card][i][j]!=0.0) {
-			for(int k=0;k<(2*n);k++) {
-			  ((int16_t *)alsa_format->card_buffer)[modulo*k+2*i]+=
-			   (int16_t)(alsa_output_volume[alsa_format->card][i][j]*
-				   (double)(((int16_t *)alsa_buffer)[k]));
-			  ((int16_t *)alsa_format->card_buffer)[modulo*k+2*i+1]+=
-			   (int16_t)(alsa_output_volume[alsa_format->card][i][j]*
-				   (double)(((int16_t *)alsa_buffer)[k]));
-			}
-		      }
-		    }
-		    n*=2;
-		    break;
+    case SND_PCM_FORMAT_S16_LE:
+      for(unsigned j=0;j<RD_MAX_STREAMS;j++) {
+        if(alsa_playing[alsa_format->card][j]) {
+          switch(alsa_output_channels[alsa_format->card][j]) {
+          case 1:
+            n=alsa_play_ring[alsa_format->card][j]->
+              read(alsa_buffer,alsa_format->
+                   buffer_size/alsa_format->periods)/
+              (2*sizeof(int16_t));
+            stream_out_meter=0;  // Stream Output Meters
+            for(int k=0;k<n;k++) {
+              if(abs(((int16_t *)alsa_buffer)[k])>stream_out_meter) {
+                stream_out_meter=abs(((int16_t *)alsa_buffer)[k]);
+              }
+            }
+            alsa_stream_output_meter[alsa_format->card][j][0]->
+              addValue(((double)stream_out_meter)/32768.0);
+            alsa_stream_output_meter[alsa_format->card][j][1]->
+              addValue(((double)stream_out_meter)/32768.0);
+            modulo=alsa_format->channels;
+            for(unsigned i=0;i<(alsa_format->channels/2);i++) {
+              if(alsa_output_volume[alsa_format->card][i][j]!=0.0) {
+                for(int k=0;k<(2*n);k++) {
+                  ((int16_t *)alsa_format->card_buffer)[modulo*k+2*i]+=
+                    (int16_t)(alsa_output_volume[alsa_format->card][i][j]*
+                              (double)(((int16_t *)alsa_buffer)[k]));
+                  ((int16_t *)alsa_format->card_buffer)[modulo*k+2*i+1]+=
+                    (int16_t)(alsa_output_volume[alsa_format->card][i][j]*
+                              (double)(((int16_t *)alsa_buffer)[k]));
+                }
+              }
+            }
+            n*=2;
+            break;
 
-		  case 2:
-		    n=alsa_play_ring[alsa_format->card][j]->
-		      read(alsa_buffer,alsa_format->buffer_size*2/
-			   alsa_format->periods)/(2*sizeof(int16_t));
-		    for(unsigned k=0;k<2;k++) {  // Stream Output Meters
-		      stream_out_meter=0;
-		      for(int l=0;l<n;l+=2) {
-			if(abs(((int16_t *)alsa_buffer)[l+k])>stream_out_meter) {
-			  stream_out_meter=abs(((int16_t *)alsa_buffer)[l+k]);
-			}
-		      }
-		      alsa_stream_output_meter[alsa_format->card][j][k]->
-			addValue(((double)stream_out_meter)/32768.0);
-		    }
-		    modulo=alsa_format->channels;
-		    for(unsigned i=0;i<(alsa_format->channels/2);i++) {
-		      if(alsa_output_volume[alsa_format->card][i][j]!=0.0) {
-			for(int k=0;k<n;k++) {
-			  ((int16_t *)alsa_format->card_buffer)[modulo*k+2*i]+=
-			   (int16_t)(alsa_output_volume[alsa_format->card][i][j]*
-				   (double)(((int16_t *)alsa_buffer)[2*k]));
-			  ((int16_t *)alsa_format->card_buffer)[modulo*k+2*i+1]+=
-			   (int16_t)(alsa_output_volume[alsa_format->card][i][j]*
-				   (double)(((int16_t *)alsa_buffer)[2*k+1]));
-			}
-		      }
-		    }
-		    break;
-	      }
-	      alsa_output_pos[alsa_format->card][j]+=n;
-	      if((n==0)&&alsa_eof[alsa_format->card][j]) {
-		alsa_stopping[alsa_format->card][j]=true;
-	      }
-	    }
-	  }
-	  n=alsa_format->buffer_size/(2*alsa_format->periods);
+          case 2:
+            n=alsa_play_ring[alsa_format->card][j]->
+              read(alsa_buffer,alsa_format->buffer_size*2/
+                   alsa_format->periods)/(2*sizeof(int16_t));
+            for(unsigned k=0;k<2;k++) {  // Stream Output Meters
+              stream_out_meter=0;
+              for(int l=0;l<n;l+=2) {
+                if(abs(((int16_t *)alsa_buffer)[l+k])>stream_out_meter) {
+                  stream_out_meter=abs(((int16_t *)alsa_buffer)[l+k]);
+                }
+              }
+              alsa_stream_output_meter[alsa_format->card][j][k]->
+                addValue(((double)stream_out_meter)/32768.0);
+            }
+            modulo=alsa_format->channels;
+            for(unsigned i=0;i<(alsa_format->channels/2);i++) {
+              if(alsa_output_volume[alsa_format->card][i][j]!=0.0) {
+                for(int k=0;k<n;k++) {
+                  ((int16_t *)alsa_format->card_buffer)[modulo*k+2*i]+=
+                    (int16_t)(alsa_output_volume[alsa_format->card][i][j]*
+                              (double)(((int16_t *)alsa_buffer)[2*k]));
+                  ((int16_t *)alsa_format->card_buffer)[modulo*k+2*i+1]+=
+                    (int16_t)(alsa_output_volume[alsa_format->card][i][j]*
+                              (double)(((int16_t *)alsa_buffer)[2*k+1]));
+                }
+              }
+            }
+            break;
+          }
+          alsa_output_pos[alsa_format->card][j]+=n;
+          if((n==0)&&alsa_eof[alsa_format->card][j]) {
+            alsa_stopping[alsa_format->card][j]=true;
+          }
+        }
+      }
+      n=alsa_format->buffer_size/(2*alsa_format->periods);
 
-	  //
-	  // Process Passthroughs
-	  //
-	  for(unsigned i=0;i<alsa_format->capture_channels;i+=2) {
-	    p=alsa_passthrough_ring[alsa_format->card][i/2]->
-	      read(alsa_format->passthrough_buffer,4*n)/4;
-	    for(unsigned j=0;j<alsa_format->channels;j+=2) {
-	      for(unsigned k=0;k<2;k++) {
-		for(int l=0;l<p;l++) {
-		  ((int16_t *)alsa_format->
-		   card_buffer)[alsa_format->channels*l+j+k]+=
-		    (int16_t)((double)((int16_t *)
-				       alsa_format->passthrough_buffer)[2*l+k]*
-			alsa_passthrough_volume[alsa_format->card][i/2][j/2]);
-		}
-	      }
-	    }
-	  }
+      //
+      // Process Passthroughs
+      //
+      for(unsigned i=0;i<alsa_format->capture_channels;i+=2) {
+        p=alsa_passthrough_ring[alsa_format->card][i/2]->
+          read(alsa_format->passthrough_buffer,4*n)/4;
+        for(unsigned j=0;j<alsa_format->channels;j+=2) {
+          for(unsigned k=0;k<2;k++) {
+            for(int l=0;l<p;l++) {
+              ((int16_t *)alsa_format->
+               card_buffer)[alsa_format->channels*l+j+k]+=
+                (int16_t)((double)((int16_t *)
+                                   alsa_format->passthrough_buffer)[2*l+k]*
+                          alsa_passthrough_volume[alsa_format->card][i/2][j/2]);
+            }
+          }
+        }
+      }
 
-	  //
-	  // Process Output Meters
-	  //
-	  for(unsigned i=0;i<alsa_format->channels;i+=2) {
-	    unsigned port=i/2;
-	    for(unsigned j=0;j<2;j++) {
-	      out_meter[port][j]=0;
-	      for(unsigned k=0;k<alsa_format->buffer_size;k++) {
-		if(((int16_t *)alsa_format->
-		    card_buffer)[alsa_format->channels*k+2*i+j]>
-		   out_meter[i][j]) {
-		  out_meter[i][j]=
-		    ((int16_t *)alsa_format->
-		     card_buffer)[alsa_format->channels*k+2*i+j];
-		}
-	      }
-	      alsa_output_meter[alsa_format->card][i][j]->
-		addValue(((double)out_meter[i][j])/32768.0);
-	    }
-	  }
-	  break;
+      //
+      // Process Output Meters
+      //
+      for(unsigned i=0;i<alsa_format->channels;i+=2) {
+        unsigned port=i/2;
+        for(unsigned j=0;j<2;j++) {
+          out_meter[port][j]=0;
+          for(unsigned k=0;k<alsa_format->buffer_size;k++) {
+            if(((int16_t *)alsa_format->
+                card_buffer)[alsa_format->channels*k+2*i+j]>
+               out_meter[i][j]) {
+              out_meter[i][j]=
+                ((int16_t *)alsa_format->
+                 card_buffer)[alsa_format->channels*k+2*i+j];
+            }
+          }
+          alsa_output_meter[alsa_format->card][i][j]->
+            addValue(((double)out_meter[i][j])/32768.0);
+        }
+      }
+      break;
 
-	case SND_PCM_FORMAT_S32_LE:
-	  for(unsigned j=0;j<RD_MAX_STREAMS;j++) {
-	    if(alsa_playing[alsa_format->card][j]) {
-	      switch(alsa_output_channels[alsa_format->card][j]) {
-		  case 1:
-		    n=alsa_play_ring[alsa_format->card][j]->
-		      read(alsa_buffer,alsa_format->buffer_size/
-			   alsa_format->periods)/(2*sizeof(int16_t));
-		    stream_out_meter=0;
-		    for(int k=0;k<n;k++) {  // Stream Output Meters
-		      if(abs(((int16_t *)alsa_buffer)[k])>stream_out_meter) {
-			stream_out_meter=abs(((int16_t *)alsa_buffer)[k]);
-		      }
-		    }
-		    alsa_stream_output_meter[alsa_format->card][j][0]->
-		      addValue(((double)stream_out_meter)/32768.0);
-		    alsa_stream_output_meter[alsa_format->card][j][1]->
-		      addValue(((double)stream_out_meter)/32768.0);
-		    modulo=alsa_format->channels*2;
-		    for(unsigned i=0;i<(alsa_format->channels/2);i++) {
-		      if(alsa_output_volume[alsa_format->card][i][j]!=0.0) {
-			for(int k=0;k<(2*n);k++) {
-			  ((int16_t *)alsa_format->card_buffer)[modulo*k+4*i+1]+=
-			   (int16_t)(alsa_output_volume[alsa_format->card][i][j]*
-				   (double)(((int16_t *)alsa_buffer)[k]));
-			  ((int16_t *)alsa_format->card_buffer)[modulo*k+4*i+3]+=
-			   (int16_t)(alsa_output_volume[alsa_format->card][i][j]*
-				   (double)(((int16_t *)alsa_buffer)[k]));
-			}
-		      }
-		    }
-		    n*=2;
-		    break;
+    case SND_PCM_FORMAT_S32_LE:
+      for(unsigned j=0;j<RD_MAX_STREAMS;j++) {
+        if(alsa_playing[alsa_format->card][j]) {
+          switch(alsa_output_channels[alsa_format->card][j]) {
+          case 1:
+            n=alsa_play_ring[alsa_format->card][j]->
+              read(alsa_buffer,alsa_format->buffer_size/
+                   alsa_format->periods)/(2*sizeof(int16_t));
+            stream_out_meter=0;
+            for(int k=0;k<n;k++) {  // Stream Output Meters
+              if(abs(((int16_t *)alsa_buffer)[k])>stream_out_meter) {
+                stream_out_meter=abs(((int16_t *)alsa_buffer)[k]);
+              }
+            }
+            alsa_stream_output_meter[alsa_format->card][j][0]->
+              addValue(((double)stream_out_meter)/32768.0);
+            alsa_stream_output_meter[alsa_format->card][j][1]->
+              addValue(((double)stream_out_meter)/32768.0);
+            modulo=alsa_format->channels*2;
+            for(unsigned i=0;i<(alsa_format->channels/2);i++) {
+              if(alsa_output_volume[alsa_format->card][i][j]!=0.0) {
+                for(int k=0;k<(2*n);k++) {
+                  ((int16_t *)alsa_format->card_buffer)[modulo*k+4*i+1]+=
+                    (int16_t)(alsa_output_volume[alsa_format->card][i][j]*
+                              (double)(((int16_t *)alsa_buffer)[k]));
+                  ((int16_t *)alsa_format->card_buffer)[modulo*k+4*i+3]+=
+                    (int16_t)(alsa_output_volume[alsa_format->card][i][j]*
+                              (double)(((int16_t *)alsa_buffer)[k]));
+                }
+              }
+            }
+            n*=2;
+            break;
 
-		  case 2:
-		    n=alsa_play_ring[alsa_format->card][j]->
-		      read(alsa_buffer,alsa_format->buffer_size*2/
-			   alsa_format->periods)/(2*sizeof(int16_t));
-		    for(unsigned k=0;k<2;k++) {  // Stream Output Meters
-		      stream_out_meter=0;
-		      for(int l=0;l<n;l+=2) {
-			if(abs(((int16_t *)alsa_buffer)[l+k])>stream_out_meter) {
-			  stream_out_meter=abs(((int16_t *)alsa_buffer)[l+k]);
-			}
-		      }
-		      alsa_stream_output_meter[alsa_format->card][j][k]->
-			addValue(((double)stream_out_meter)/32768.0);
-		    }
-		    modulo=alsa_format->channels*2;
-		    for(unsigned i=0;i<(alsa_format->channels/2);i++) {
-		      if(alsa_output_volume[alsa_format->card][i][j]!=0.0) {
-			for(int k=0;k<n;k++) {
-			  ((int16_t *)alsa_format->card_buffer)[modulo*k+4*i+1]+=
-			   (int16_t)(alsa_output_volume[alsa_format->card][i][j]*
-				   (double)(((int16_t *)alsa_buffer)[2*k]));
-			  ((int16_t *)alsa_format->card_buffer)[modulo*k+4*i+3]+=
-			   (int16_t)(alsa_output_volume[alsa_format->card][i][j]*
-				   (double)(((int16_t *)alsa_buffer)[2*k+1]));
-			}
-		      }
-		    }
-		    break;
-	      }
-	      alsa_output_pos[alsa_format->card][j]+=n;
-	      if((n==0)&&alsa_eof[alsa_format->card][j]) {
-		alsa_stopping[alsa_format->card][j]=true;
-		// Empty the ring buffer
-		while(alsa_play_ring[alsa_format->card][j]->
-		      read(alsa_buffer,alsa_format->buffer_size*2/
-			   alsa_format->periods)/(2*sizeof(int16_t))>0);	       
-	      }
-	    }
-	  }
-	  n=alsa_format->buffer_size/(2*alsa_format->periods);
+          case 2:
+            n=alsa_play_ring[alsa_format->card][j]->
+              read(alsa_buffer,alsa_format->buffer_size*2/
+                   alsa_format->periods)/(2*sizeof(int16_t));
+            for(unsigned k=0;k<2;k++) {  // Stream Output Meters
+              stream_out_meter=0;
+              for(int l=0;l<n;l+=2) {
+                if(abs(((int16_t *)alsa_buffer)[l+k])>stream_out_meter) {
+                  stream_out_meter=abs(((int16_t *)alsa_buffer)[l+k]);
+                }
+              }
+              alsa_stream_output_meter[alsa_format->card][j][k]->
+                addValue(((double)stream_out_meter)/32768.0);
+            }
+            modulo=alsa_format->channels*2;
+            for(unsigned i=0;i<(alsa_format->channels/2);i++) {
+              if(alsa_output_volume[alsa_format->card][i][j]!=0.0) {
+                for(int k=0;k<n;k++) {
+                  ((int16_t *)alsa_format->card_buffer)[modulo*k+4*i+1]+=
+                    (int16_t)(alsa_output_volume[alsa_format->card][i][j]*
+                              (double)(((int16_t *)alsa_buffer)[2*k]));
+                  ((int16_t *)alsa_format->card_buffer)[modulo*k+4*i+3]+=
+                    (int16_t)(alsa_output_volume[alsa_format->card][i][j]*
+                              (double)(((int16_t *)alsa_buffer)[2*k+1]));
+                }
+              }
+            }
+            break;
+          }
+          alsa_output_pos[alsa_format->card][j]+=n;
+          if((n==0)&&alsa_eof[alsa_format->card][j]) {
+            alsa_stopping[alsa_format->card][j]=true;
+            // Empty the ring buffer
+            while(alsa_play_ring[alsa_format->card][j]->
+                  read(alsa_buffer,alsa_format->buffer_size*2/
+                       alsa_format->periods)/(2*sizeof(int16_t))>0);
+          }
+        }
+      }
+      n=alsa_format->buffer_size/(2*alsa_format->periods);
 
-	  //
-	  // Process Passthroughs
-	  //
-	  for(unsigned i=0;i<alsa_format->capture_channels;i+=2) {
-	    p=alsa_passthrough_ring[alsa_format->card][i/2]->
-	      read(alsa_format->passthrough_buffer,8*n)/8;
-	    for(unsigned j=0;j<alsa_format->channels;j+=2) {
-	      for(unsigned k=0;k<2;k++) {
-		for(int l=0;l<p;l++) {
-		  ((int32_t *)alsa_format->
-		   card_buffer)[alsa_format->channels*l+j+k]+=
-		    (int32_t)((double)((int32_t *)
-				       alsa_format->passthrough_buffer)[2*l+k]*
-			alsa_passthrough_volume[alsa_format->card][i/2][j/2]);
-		}
-	      }
-	    }
-	  }
+      //
+      // Process Passthroughs
+      //
+      for(unsigned i=0;i<alsa_format->capture_channels;i+=2) {
+        p=alsa_passthrough_ring[alsa_format->card][i/2]->
+          read(alsa_format->passthrough_buffer,8*n)/8;
+        for(unsigned j=0;j<alsa_format->channels;j+=2) {
+          for(unsigned k=0;k<2;k++) {
+            for(int l=0;l<p;l++) {
+              ((int32_t *)alsa_format->
+               card_buffer)[alsa_format->channels*l+j+k]+=
+                (int32_t)((double)((int32_t *)
+                                   alsa_format->passthrough_buffer)[2*l+k]*
+                          alsa_passthrough_volume[alsa_format->card][i/2][j/2]);
+            }
+          }
+        }
+      }
 
-	  //
-	  // Process Output Meters
-	  //
-	  for(unsigned i=0;i<alsa_format->channels;i+=2) {
-	    unsigned port=i/2;
-	    for(unsigned j=0;j<2;j++) {
-	      out_meter[port][j]=0;
-	      for(unsigned k=0;
-		  k<(alsa_format->buffer_size*2/alsa_format->periods);
-		  k++) {
-		if(((int16_t *)alsa_format->
-		    card_buffer)[alsa_format->channels*2*k+2*i+1+2*j]>
-		   out_meter[port][j]) {
-		  out_meter[port][j]=
-		    ((int16_t *)alsa_format->
-		     card_buffer)[alsa_format->channels*2*k+2*i+1+2*j];
-		}
-	      }
-	      alsa_output_meter[alsa_format->card][port][j]->
-		addValue(((double)out_meter[port][j])/32768.0);
-	    }
-	  }
-	  break;
+      //
+      // Process Output Meters
+      //
+      for(unsigned i=0;i<alsa_format->channels;i+=2) {
+        unsigned port=i/2;
+        for(unsigned j=0;j<2;j++) {
+          out_meter[port][j]=0;
+          for(unsigned k=0;
+              k<(alsa_format->buffer_size*2/alsa_format->periods);
+              k++) {
+            if(((int16_t *)alsa_format->
+                card_buffer)[alsa_format->channels*2*k+2*i+1+2*j]>
+               out_meter[port][j]) {
+              out_meter[port][j]=
+                ((int16_t *)alsa_format->
+                 card_buffer)[alsa_format->channels*2*k+2*i+1+2*j];
+            }
+          }
+          alsa_output_meter[alsa_format->card][port][j]->
+            addValue(((double)out_meter[port][j])/32768.0);
+        }
+      }
+      break;
 
-	default:
-	  break;
+    default:
+      break;
     }
     int s=snd_pcm_writei(alsa_format->pcm,alsa_format->card_buffer,n);
     if(s!=n) {
       if(s<0) {
-	LogLine(RDConfig::LogNotice,
-		QString().sprintf("*** alsa error %d: %s",-s,snd_strerror(s)));
+        LogLine(RDConfig::LogNotice,
+                QString().sprintf("*** alsa error %d: %s",-s,snd_strerror(s)));
       }
       else {
-	LogLine(RDConfig::LogNotice,
-		QString().sprintf("period size mismatch - wrote %d\n",s));
+        LogLine(RDConfig::LogNotice,
+                QString().sprintf("period size mismatch - wrote %d\n",s));
       }
     }
     if((snd_pcm_state(alsa_format->pcm)!=SND_PCM_STATE_RUNNING)&&
@@ -536,8 +536,8 @@ void AlsaPlay2Callback(struct alsa_format *alsa_format)
       snd_pcm_drop (alsa_format->pcm);
       snd_pcm_prepare(alsa_format->pcm);
       LogLine(RDConfig::LogNotice,QString().
-	      sprintf("****** ALSA Playout Xrun - Card: %d ******",
-		      alsa_format->card));
+              sprintf("****** ALSA Playout Xrun - Card: %d ******",
+                      alsa_format->card));
     }
   }
 }


### PR DESCRIPTION
caed alsa takes a lot of CPU. According to CPU profiling, the `AlsaPlay2Callback` is the main candidate for optimization.

This pull request provides two optimizations : 

* in Process Passthroughs, it detects when `alsa_passthrough_volume` is zero and skip the "channel".
* in Process Output Meters, it saves direct accesses in `alsa_format->card_buffer`

**Before** (about 12% of my i7 CPU) : 

```
$ google-pprof --text --lines ./cae/.libs/caed profile      
Using local file ./cae/.libs/caed.
Using local file profile.
Total: 316 samples
     245  77.5%  77.5%      283  89.6% AlsaPlay2Callback ??:?
      31   9.8%  87.3%       31   9.8% __select_nocancel /build/glibc-NmptCx/glibc-2.19/misc/../sysdeps/unix/syscall-template.S:81
      23   7.3%  94.6%       30   9.5% AlsaCapture2Callback ??:?
```

**After** (about 5.5% of my i7 CPU) : 

```
$ google-pprof --text --lines ./cae/.libs/caed profile_after 
Using local file ./cae/.libs/caed.
Using local file profile_after.
Total: 1027 samples
     405  39.4%  39.4%      775  75.5% AlsaPlay2Callback ??:?
     229  22.3%  61.7%      229  22.3% __select_nocancel /build/glibc-NmptCx/glibc-2.19/misc/../sysdeps/unix/syscall-template.S:81
     189  18.4%  80.1%      279  27.2% AlsaCapture2Callback ??:?
      20   1.9%  82.1%       26   2.5% memset /build/glibc-NmptCx/glibc-2.19/string/../sysdeps/x86_64/memset.S:94
```