### PR TITLE
Schedcartlist without arrays

### DIFF
--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -233,7 +233,8 @@ dist_librd_la_SOURCES = dbversion.h\
                         rdwebresult.cpp rdwebresult.h\
                         rdxport_interface.h\
                         schedruleslist.cpp schedruleslist.h\
-                        schedcartlist.cpp schedcartlist.h
+                        schedcartlist.cpp schedcartlist.h\
+                        schedcart.cpp schedcart.h
 
 
 nodist_librd_la_SOURCES = moc_rdadd_cart.cpp\

--- a/lib/rdevent_line.cpp
+++ b/lib/rdevent_line.cpp
@@ -693,20 +693,14 @@ bool RDEventLine::generateLog(QString logname,const QString &svcname,
       }
 
       // Must have second scheduler code
-      if(event_have_code2!="")
-      {
-	schedCL->save();
-	for(counter=0;counter<schedCL->getNumberOfItems();counter++)
-	{
-	  if(!schedCL->itemHasCode(counter,event_have_code2))
-	  {
-	    schedCL->removeItem(counter);
-	    counter--;
-	  }
-	}
-	if(schedCL->getNumberOfItems()==0)
-	  *errors+=QString().sprintf("%s Rule broken: Must have second code %s\n",(const char *)time.toString("hh:mm:ss"),(const char*)event_have_code2);
-	schedCL->restore();
+      if(!event_have_code2.isEmpty()) {
+        for (current = schedulerList->first(); current != NULL; current = current->next()) {
+          if (!current->hasSchedulerCode(event_have_code2)) {
+            current->exclude();
+          }
+        }
+
+        schedulerList->saveOrBreakRule(QString("Must have second code ") + event_have_code2, time, errors);
       }
 
       // Scheduler Codes

--- a/lib/rdevent_line.cpp
+++ b/lib/rdevent_line.cpp
@@ -667,7 +667,7 @@ bool RDEventLine::generateLog(QString logname,const QString &svcname,
       schedulerList->saveOrBreakRule(QString("Title Separation"), time, errors);
       
       // Artist separation
-      sql=QString().sprintf("select ARTIST from %s_STACK where SCHED_STACK_ID >= %d",(const char*)svcname_rp,(stackid-artistsep));
+      sql=QString().sprintf("select DISTINCT(ARTIST) from %s_STACK where SCHED_STACK_ID >= %d",(const char*)svcname_rp,(stackid-artistsep));
       q=new RDSqlQuery(sql);
       while (q->next())	{
         QString stack_artist = q->value(0).toString();

--- a/lib/rdevent_line.cpp
+++ b/lib/rdevent_line.cpp
@@ -623,13 +623,11 @@ bool RDEventLine::generateLog(QString logname,const QString &svcname,
       }
       delete q;
 
-      int stackid;
-      sql=QString().sprintf("SELECT SCHED_STACK_ID from %s_STACK order by SCHED_STACK_ID",(const char*)svcname_rp);
+      int stackid = 0;
+      sql=QString().sprintf("SELECT SCHED_STACK_ID from %s_STACK order by SCHED_STACK_ID desc limit 1",(const char*)svcname_rp);
       q=new RDSqlQuery(sql);
-      if (q->last()) { 
+      if (q->next()) { 
         stackid=q->value(0).toUInt();
-      } else { 
-        stackid=0;
       }
       stackid++;    
       delete q;

--- a/lib/rdevent_line.cpp
+++ b/lib/rdevent_line.cpp
@@ -732,43 +732,38 @@ bool RDEventLine::generateLog(QString logname,const QString &svcname,
         delete q1;
 
         schedulerList->saveOrBreakRule(QString("Max. in a Row/Min. Wait for ") + code, time, errors);
-          
+
         // do not play after
-        if (!notAfterCode1.isEmpty()) {
-          QString wstr= (notAfterCode1 + QString("          ")).left(11);
-          sql=QString().sprintf("select CART from %s_STACK where SCHED_STACK_ID = %d and SCHED_CODES like \"%%%s%%\"",(const char*)svcname_rp,(stackid-1),(const char *)wstr);
+        if (!notAfterCode1.isEmpty() || !notAfterCode2.isEmpty() || !notAfterCode3.isEmpty()) {
+          sql=QString().sprintf("select SCHED_CODES from %s_STACK where SCHED_STACK_ID = %d",(const char*)svcname_rp,stackid-1);
           q1=new RDSqlQuery(sql);
-          if (q1->size()>0)	{
-            schedulerList->excludeIfCode(notAfterCode1);
-          }
-          delete q1;
+          if (q1->next())	{
+            QString lastSchedulerCodes = q1->value(0).toString();
 
-          schedulerList->saveOrBreakRule(QString("Do not schedule ") + code + QString(" after ") + notAfterCode1, time, errors);
-        }
-        // or after
-        if (!notAfterCode2.isEmpty()) {
-          QString wstr= (notAfterCode2 + QString("          ")).left(11);
-          sql=QString().sprintf("select CART from %s_STACK where SCHED_STACK_ID = %d and SCHED_CODES like \"%%%s%%\"",(const char*)svcname_rp,(stackid-1),(const char *)wstr);
-          q1=new RDSqlQuery(sql);
-          if (q1->size()>0)	{
-            schedulerList->excludeIfCode(notAfterCode2);
-          }
-          delete q1;
+            if (!notAfterCode1.isEmpty()) {
+              QString test= (notAfterCode1 + QString("          ")).left(11);
+              if (lastSchedulerCodes.find(test) >= 0) {
+                schedulerList->excludeIfCode(code);
+                schedulerList->saveOrBreakRule(QString("Do not schedule ") + code + QString(" after ") + notAfterCode1, time, errors);
+              }
+            }
 
-          schedulerList->saveOrBreakRule(QString("Do not schedule ") + code + QString(" after ") + notAfterCode2, time, errors);
-        }
-        
-        // or after II
-        if (!notAfterCode3.isEmpty()) {
-          QString wstr= (notAfterCode3 + QString("          ")).left(11);
-          sql=QString().sprintf("select CART from %s_STACK where SCHED_STACK_ID = %d and SCHED_CODES like \"%%%s%%\"",(const char*)svcname_rp,(stackid-1),(const char *)wstr);
-          q1=new RDSqlQuery(sql);
-          if (q1->size()>0)	{
-            schedulerList->excludeIfCode(notAfterCode3);
-          }
-          delete q1;
+            if (!notAfterCode2.isEmpty()) {
+              QString test= (notAfterCode2 + QString("          ")).left(11);
+              if (lastSchedulerCodes.find(test) >= 0) {
+                schedulerList->excludeIfCode(code);
+                schedulerList->saveOrBreakRule(QString("Do not schedule ") + code + QString(" after ") + notAfterCode2, time, errors);
+              }
+            }
 
-          schedulerList->saveOrBreakRule(QString("Do not schedule ") + code + QString(" after ") + notAfterCode3, time, errors);
+            if (!notAfterCode3.isEmpty()) {
+              QString test= (notAfterCode3 + QString("          ")).left(11);
+              if (lastSchedulerCodes.find(test) >= 0) {
+                schedulerList->excludeIfCode(code);
+                schedulerList->saveOrBreakRule(QString("Do not schedule ") + code + QString(" after ") + notAfterCode3, time, errors);
+              }
+            }
+          }
         }
       }
       delete q;

--- a/lib/rdevent_line.cpp
+++ b/lib/rdevent_line.cpp
@@ -598,9 +598,6 @@ bool RDEventLine::generateLog(QString logname,const QString &svcname,
 // Scheduler 
 
   if(event_import_source == RDEventLine::Scheduler ) {
-    int titlesep;
-    int stackid;
-    int counter;   		
     RDLogLine::Source source=RDLogLine::Music;
     
     QString svcname_rp = svcname;
@@ -611,103 +608,74 @@ bool RDEventLine::generateLog(QString logname,const QString &svcname,
     sql=QString().sprintf("select NUMBER,ARTIST,SCHED_CODES from CART where GROUP_NAME='%s'",(const char *)SchedGroup()); 
     
     q=new RDSqlQuery(sql);
-    if(q->size()>0)
-    {
-      if(event_title_sep>=0 && event_title_sep<=50000)
-      {
-	titlesep = (int)event_title_sep;
-      }
-      else
-      {
-	titlesep = 100;
+    if (q->size()>0) {
+      int titlesep;
+      if (event_title_sep>=0 && event_title_sep<=50000) {
+        titlesep = (int)event_title_sep;
+      } else {
+        titlesep = 100;
       }
       
-      int querysize=(int)q->size();
-      SchedCartList *schedCL;
-      schedCL=new SchedCartList(querysize);
+      SchedCartList *schedulerList = new SchedCartList();
       
-      for(counter=0;counter<querysize;counter++)
-      {
-	q->seek(counter);
-	schedCL->insertItem(q->value(0).toUInt(),0,0,q->value(1).toString(),q->value(2).toString());
+      while (q->next())	{
+        schedulerList->insert(q->value(0).toUInt(),q->value(1).toString(),q->value(2).toString());
       }
       delete q;
-      
+
+      int stackid;
       sql=QString().sprintf("SELECT SCHED_STACK_ID from %s_STACK order by SCHED_STACK_ID",(const char*)svcname_rp);
       q=new RDSqlQuery(sql);
-      if (q->last())
-      { 
-	stackid=q->value(0).toUInt();
-      }
-      else
-      { 
-	stackid=0;
+      if (q->last()) { 
+        stackid=q->value(0).toUInt();
+      } else { 
+        stackid=0;
       }
       stackid++;    
       delete q;
-      
+
+      SchedCart *current = NULL;
       
       // Add deconflicting rules here		  
       // Title separation 
-      schedCL->save();		  
-      sql=QString().sprintf("select CART from %s_STACK \
-			  where SCHED_STACK_ID >= %d",(const char*)svcname_rp,(stackid-titlesep));
+      sql=QString().sprintf("select CART from %s_STACK where SCHED_STACK_ID >= %d",(const char*)svcname_rp,(stackid-titlesep));
       q=new RDSqlQuery(sql);
-      
-      while (q->next())	
-      {
-	for(counter=0;counter<schedCL->getNumberOfItems();counter++)
-	{ 
-	  if(q->value(0).toUInt()==schedCL->getItemCartnumber(counter))
-	  {
-	    schedCL->removeItem(counter);
-	    counter--;
-	  }
-	}
-      }          
+      while (q->next())	{
+        unsigned cartStack = q->value(0).toUInt();
+        for (current = schedulerList->first(); current != NULL; current = current->next()) {
+          if (current->getCartNumber() == cartStack) {
+            current->exclude();
+          }
+        }
+      }      
       delete q;
-      if(schedCL->getNumberOfItems()==0)
-	*errors+=QString().sprintf("%s Rule broken: Title Separation\n",(const char *)time.toString("hh:mm:ss"));
-      schedCL->restore();
+      
+      schedulerList->saveOrBreakRule(QString("Title Separation"), time, errors);
       
       // Artist separation
-      schedCL->save();		  
-      sql=QString().sprintf("select ARTIST from %s_STACK \
-			  where SCHED_STACK_ID >= %d",(const char*)svcname_rp,(stackid-artistsep));
+      sql=QString().sprintf("select ARTIST from %s_STACK where SCHED_STACK_ID >= %d",(const char*)svcname_rp,(stackid-artistsep));
       q=new RDSqlQuery(sql);
-      
-      while (q->next())	
-      {
-	for(counter=0;counter<schedCL->getNumberOfItems();counter++)
-	{ 
-	  if(q->value(0).toString()==schedCL->getItemArtist(counter))
-	  {
-	    schedCL->removeItem(counter);
-	    counter--;
-	  }
-	}
+      while (q->next())	{
+        QString stack_artist = q->value(0).toString();
+        for (current = schedulerList->first(); current != NULL; current = current->next()) {
+          if (current->getArtist() == stack_artist) {
+            current->exclude();
+          }
+        }
       }          
-      
       delete q;
-      if(schedCL->getNumberOfItems()==0)
-	*errors+=QString().sprintf("%s Rule broken: Artist Separation\n",(const char *)time.toString("hh:mm:ss"));
-      schedCL->restore();
+
+      schedulerList->saveOrBreakRule(QString("Artist Separation"), time, errors);
       
       // Must have scheduler code
-      if(event_have_code!="")
-      {
-	schedCL->save();		  
-	for(counter=0;counter<schedCL->getNumberOfItems();counter++)
-	{ 
-	  if(!schedCL->itemHasCode(counter,event_have_code))
-	  {
-	    schedCL->removeItem(counter);
-	    counter--;
-	  }
-	}
-	if(schedCL->getNumberOfItems()==0)
-	  *errors+=QString().sprintf("%s Rule broken: Must have code %s\n",(const char *)time.toString("hh:mm:ss"),(const char*)event_have_code);
-	schedCL->restore();
+      if(!event_have_code.isEmpty()) {
+        for (current = schedulerList->first(); current != NULL; current = current->next()) {
+          if (!current->hasSchedulerCode(event_have_code)) {
+            current->exclude();
+          }
+        }
+
+        schedulerList->saveOrBreakRule(QString("Must have code ") + event_have_code, time, errors);
       }
 
       // Must have second scheduler code
@@ -730,120 +698,98 @@ bool RDEventLine::generateLog(QString logname,const QString &svcname,
       // Scheduler Codes
       sql=QString().sprintf("select CODE,MAX_ROW,MIN_WAIT,NOT_AFTER, OR_AFTER,OR_AFTER_II from %s_RULES",(const char *)clockname);
       q=new RDSqlQuery(sql);
-      while (q->next())
-      {
-	// max in a row, min wait
-	schedCL->save();	
-	int range=q->value(1).toInt()+q->value(2).toInt(); 
-	int allowed=q->value(1).toInt();
-	QString wstr=q->value(0).toString();
-	wstr+="          ";
-	wstr=wstr.left(11);
-	sql=QString().sprintf("select CART from %s_STACK \
-			  where SCHED_STACK_ID > %d and SCHED_CODES like \"%%%s%%\"",(const char*)svcname_rp,(stackid-range),(const char *)wstr);
-	q1=new RDSqlQuery(sql);
-	if (q1->size()>=allowed || allowed==0)	
-	  for(counter=0;counter<schedCL->getNumberOfItems();counter++)
-	    if (                           schedCL->removeIfCode(counter,q->value(0).toString()))
-	      counter--;
-	delete q1;
-	if(schedCL->getNumberOfItems()==0)
-	  *errors+=QString().sprintf("%s Rule broken: Max. in a Row/Min. Wait for %s\n",(const char *)time.toString("hh:mm:ss"),(const char *)q->value(0).toString());
-	schedCL->restore();
-	// do not play after
-	if (q->value(3).toString()!="")
-	{ 
-	  schedCL->save();	
-	  QString wstr=q->value(3).toString();
-	  wstr+="          ";
-	  wstr=wstr.left(11);
-	  sql=QString().sprintf("select CART from %s_STACK \
-			  where SCHED_STACK_ID = %d and SCHED_CODES like \"%%%s%%\"",(const char*)svcname_rp,(stackid-1),(const char *)wstr);
-	  q1=new RDSqlQuery(sql);
-	  if (q1->size()>0)	
-	    for(counter=0;counter<schedCL->getNumberOfItems();counter++)
-	      if (                           schedCL->removeIfCode(counter,q->value(0).toString()))
-		counter--;
-	  delete q1;
-	  if(schedCL->getNumberOfItems()==0)
-	    *errors+=QString().sprintf("%s Rule broken: Do not schedule %s after %s\n",(const char *)time.toString("hh:mm:ss"),(const char *)q->value(0).toString(),(const char *)q->value(3).toString());
-	  schedCL->restore();
-	}
-	// or after
-	if (q->value(4).toString()!="")
-	{ 
-	  schedCL->save();
-	  QString wstr=q->value(4).toString();
-	  wstr+="          ";
-	  wstr=wstr.left(11);
-	  sql=QString().sprintf("select CART from %s_STACK \
-			  where SCHED_STACK_ID = %d and SCHED_CODES like \"%%%s%%\"",(const char*)svcname_rp,(stackid-1),(const char *)wstr);
-	  q1=new RDSqlQuery(sql);
-	  if (q1->size()>0)	
-	    for(counter=0;counter<schedCL->getNumberOfItems();counter++)
-	      if (                           schedCL->removeIfCode(counter,q->value(0).toString()))
-		counter--;
-	  delete q1;
-	  if(schedCL->getNumberOfItems()==0)
-	    *errors+=QString().sprintf("%s Rule broken: Do not schedule %s after %s\n",(const char *)time.toString("hh:mm:ss"),(const char *)q->value(0).toString(),(const char *)q->value(4).toString());
-	  schedCL->restore();
-	}
-	// or after II
-	if (q->value(5).toString()!="")
-	{ 
-	  schedCL->save();
-	  QString wstr=q->value(5).toString();
-	  wstr+="          ";
-	  wstr=wstr.left(11);
-	  sql=QString().sprintf("select CART from %s_STACK \
-			  where SCHED_STACK_ID = %d and SCHED_CODES like \"%%%s%%\"",(const char*)svcname_rp,(stackid-1),(const char *)wstr);
-	  q1=new RDSqlQuery(sql);
-	  if (q1->size()>0)	
-	    for(counter=0;counter<schedCL->getNumberOfItems();counter++)
-	      if (                           schedCL->removeIfCode(counter,q->value(0).toString()))
-		counter--;
-	  delete q1;
-	  if(schedCL->getNumberOfItems()==0)
-	    *errors+=QString().sprintf("%s Rule broken: Do not schedule %s after %s\n",(const char *)time.toString("hh:mm:ss"),(const char *)q->value(0).toString(),(const char *)q->value(5).toString());
-	  schedCL->restore();
-	}
+      while (q->next()) {
+        // max in a row, min wait
+        QString code = q->value(0).toString();
+        int range=q->value(1).toInt()+q->value(2).toInt(); 
+        int allowed=q->value(1).toInt();
+        
+        QString notAfterCode1 = q->value(3).toString();
+        QString notAfterCode2 = q->value(4).toString();
+        QString notAfterCode3 = q->value(5).toString();
+
+        QString wstr= (code + QString("          ")).left(11);
+        sql=QString().sprintf("select CART from %s_STACK where SCHED_STACK_ID > %d and SCHED_CODES like \"%%%s%%\"",(const char*)svcname_rp,(stackid-range),(const char *)wstr);
+
+        q1=new RDSqlQuery(sql);
+        if (q1->size()>=allowed || allowed==0) {
+            schedulerList->excludeIfCode(code);
+        }
+        delete q1;
+
+        schedulerList->saveOrBreakRule(QString("Max. in a Row/Min. Wait for ") + code, time, errors);
+          
+        // do not play after
+        if (!notAfterCode1.isEmpty()) {
+          QString wstr= (notAfterCode1 + QString("          ")).left(11);
+          sql=QString().sprintf("select CART from %s_STACK where SCHED_STACK_ID = %d and SCHED_CODES like \"%%%s%%\"",(const char*)svcname_rp,(stackid-1),(const char *)wstr);
+          q1=new RDSqlQuery(sql);
+          if (q1->size()>0)	{
+            schedulerList->excludeIfCode(notAfterCode1);
+          }
+          delete q1;
+
+          schedulerList->saveOrBreakRule(QString("Do not schedule ") + code + QString(" after ") + notAfterCode1, time, errors);
+        }
+        // or after
+        if (!notAfterCode2.isEmpty()) {
+          QString wstr= (notAfterCode2 + QString("          ")).left(11);
+          sql=QString().sprintf("select CART from %s_STACK where SCHED_STACK_ID = %d and SCHED_CODES like \"%%%s%%\"",(const char*)svcname_rp,(stackid-1),(const char *)wstr);
+          q1=new RDSqlQuery(sql);
+          if (q1->size()>0)	{
+            schedulerList->excludeIfCode(notAfterCode2);
+          }
+          delete q1;
+
+          schedulerList->saveOrBreakRule(QString("Do not schedule ") + code + QString(" after ") + notAfterCode2, time, errors);
+        }
+        
+        // or after II
+        if (!notAfterCode3.isEmpty()) {
+          QString wstr= (notAfterCode3 + QString("          ")).left(11);
+          sql=QString().sprintf("select CART from %s_STACK where SCHED_STACK_ID = %d and SCHED_CODES like \"%%%s%%\"",(const char*)svcname_rp,(stackid-1),(const char *)wstr);
+          q1=new RDSqlQuery(sql);
+          if (q1->size()>0)	{
+            schedulerList->excludeIfCode(notAfterCode3);
+          }
+          delete q1;
+
+          schedulerList->saveOrBreakRule(QString("Do not schedule ") + code + QString(" after ") + notAfterCode3, time, errors);
+        }
       }
       delete q;
       
+      // end of deconflicting rules
       
-// end of deconflicting rules
-      
-      int schedpos = rand()%schedCL->getNumberOfItems();
+      SchedCart *selected = schedulerList->sample();
       sql=QString().sprintf("insert into `%s_LOG` set ID=%d,COUNT=%d,TYPE=%d,\
 			     SOURCE=%d,START_TIME=%d,GRACE_TIME=%d, \
 			     CART_NUMBER=%u,TIME_TYPE=%d,POST_POINT=\"%s\", \
 			     TRANS_TYPE=%d,EXT_START_TIME=\"%s\",\
                              EVENT_LENGTH=%d",
-			    (const char *)logname,count,count,
-			    RDLogLine::Cart,source,
-			    QTime().msecsTo(time),
-			    grace_time,
-			    schedCL->getItemCartnumber(schedpos),
-			    time_type,
-			    (const char *)RDYesNo(post_point),
-			    trans_type,
-			    (const char *)time.toString("hh:mm:ss"),
-			    event_length);
+                            (const char *)logname,count,count,
+                            RDLogLine::Cart,source,
+                            QTime().msecsTo(time),
+                            grace_time,
+                            selected->getCartNumber(),
+                            time_type,
+                            (const char *)RDYesNo(post_point),
+                            trans_type,
+                            (const char *)time.toString("hh:mm:ss"),
+                            event_length);
       q=new RDSqlQuery(sql);
       delete q;
-
-
 
       count++;
 
-
-
       sql=QString().sprintf("insert into `%s_STACK` set SCHED_STACK_ID=%u,CART=%u,ARTIST=\"%s\",SCHED_CODES=\"%s\"",(const char*)svcname_rp,
-			    stackid,schedCL->getItemCartnumber(schedpos),
-			    (const char *)RDEscapeString(schedCL->getItemArtist(schedpos)),(const char *)schedCL->getItemSchedCodes(schedpos));
+                            stackid,
+                            selected->getCartNumber(),
+                            (const char *)RDEscapeString(selected->getArtist()),
+                            (const char *)selected->getSchedCodes());
       q=new RDSqlQuery(sql);
       delete q;
-      delete schedCL;
+      delete schedulerList;
     }
     else
     {

--- a/lib/schedcart.cpp
+++ b/lib/schedcart.cpp
@@ -1,0 +1,89 @@
+// schedcartlist.cpp
+//
+// A class for handling cart to be used in scheduler
+//
+//   Alban Peignier <alban@tryphon.eu>
+//
+//   This program is free software; you can redistribute it and/or modify
+//   it under the terms of the GNU General Public License version 2 as
+//   published by the Free Software Foundation.
+//
+//   This program is distributed in the hope that it will be useful,
+//   but WITHOUT ANY WARRANTY; without even the implied warranty of
+//   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//   GNU General Public License for more details.
+//
+//   You should have received a copy of the GNU General Public
+//   License along with this program; if not, write to the Free Software
+//   Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+//
+
+#include <schedcart.h>
+
+SchedCart::SchedCart(unsigned cartNumber, QString cartArtist,QString cartSchedCodes)
+{
+	cart_number=cartNumber;
+	artist=cartArtist;
+	sched_codes=cartSchedCodes;
+  
+  excluded=false;
+  next_sched_cart=NULL;
+  previous_sched_cart=NULL;
+}
+
+SchedCart::~SchedCart()
+{
+}
+
+unsigned SchedCart::getCartNumber()
+{
+	return cart_number;
+}
+
+QString SchedCart::getArtist()
+{
+	return artist;
+}
+
+QString SchedCart::getSchedCodes()
+{
+	return sched_codes;
+}
+
+bool SchedCart::hasSchedulerCode(QString code) {
+  QString test = (code + "          ").left(11);
+  return sched_codes.find(test) >= 0;
+}
+
+SchedCart* SchedCart::previous() {
+  return previous_sched_cart;
+}
+
+void SchedCart::setPrevious(SchedCart *schedCart) {
+  previous_sched_cart = schedCart;
+}
+
+SchedCart* SchedCart::next() {
+  return next_sched_cart;
+}
+
+void SchedCart::setNext(SchedCart *schedCart) {
+  next_sched_cart = schedCart;
+}
+
+void SchedCart::exclude() {
+  excluded = true;
+}
+
+bool SchedCart::hasBeenExcluded() {
+  return excluded;
+}
+
+void SchedCart::clearExclusion() {
+  excluded = false;
+}
+
+
+
+
+

--- a/lib/schedcart.h
+++ b/lib/schedcart.h
@@ -1,0 +1,60 @@
+// schedcart.h
+//
+// A class for handling cart to be used in scheduler
+//
+//   Alban Peignier <alban@tryphon.eu>
+//
+//   
+//
+//   This program is free software; you can redistribute it and/or modify
+//   it under the terms of the GNU General Public License version 2 as
+//   published by the Free Software Foundation.
+//
+//   This program is distributed in the hope that it will be useful,
+//   but WITHOUT ANY WARRANTY; without even the implied warranty of
+//   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//   GNU General Public License for more details.
+//
+//   You should have received a copy of the GNU General Public
+//   License along with this program; if not, write to the Free Software
+//   Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+//
+
+#include <qstring.h>
+
+#ifndef SCHEDCART_H
+#define SCHEDCART_H
+
+class SchedCart
+{
+  public:
+   SchedCart(unsigned cartnumber, QString artist,QString schedcodes);
+   ~SchedCart();
+
+   void exclude();
+   bool hasBeenExcluded();
+   void clearExclusion();
+
+   unsigned getCartNumber();
+   QString getArtist();
+   QString getSchedCodes();
+
+   bool hasSchedulerCode(QString code);
+
+   SchedCart *previous();
+   void setPrevious(SchedCart *previous);
+
+   SchedCart *next();
+   void setNext(SchedCart *next);
+   
+  private:
+   unsigned cart_number;
+   QString artist;
+   QString sched_codes;
+   bool excluded;
+
+   SchedCart *next_sched_cart;
+   SchedCart *previous_sched_cart;
+};
+
+#endif 

--- a/lib/schedcartlist.cpp
+++ b/lib/schedcartlist.cpp
@@ -21,159 +21,125 @@
 //
 
 #include <schedcartlist.h>
-
-
-SchedCartList::SchedCartList(int listsize)
+#include <stdlib.h>
+ 
+SchedCartList::SchedCartList()
 {
-	cartnum=new unsigned[listsize];
-	cartlen=new int[listsize];
-	stackid=new int[listsize];
-	artist=new QString[listsize];
-	sched_codes=new QString[listsize];
-	itemcounter=0;
+  first_sched_cart = NULL;
 }
 
 SchedCartList::~SchedCartList()
 {
-	delete []cartnum;
-	delete []cartlen;
-	delete []stackid;
-	delete []artist;
-	delete []sched_codes;
+  if (first_sched_cart == NULL) {
+    return;
+  }
+  SchedCart *current = first_sched_cart;
+  SchedCart *next = NULL;
+  
+  while (current != NULL) {
+    next = current->next();
+    delete current;
+    current = next;
+  }
 }
 
-void SchedCartList::insertItem(unsigned cartnumber,int cartlength,int stack_id,QString stack_artist,QString stack_schedcodes)
+SchedCart* SchedCartList::first()
 {
-	cartnum[itemcounter]=cartnumber;
-	cartlen[itemcounter]=cartlength;
-	stackid[itemcounter]=stack_id;
-	artist[itemcounter]=stack_artist.lower().replace(" ","");
-        sched_codes[itemcounter]=stack_schedcodes;	
-	itemcounter++;
+  return first_sched_cart;
 }
 
-
-void SchedCartList::removeItem(int itemnumber)
+void SchedCartList::insert(unsigned cartnumber,QString stack_artist,QString stack_schedcodes)
 {
-	for(int i=itemnumber;i<(itemcounter-1);i++)
-	{
-		cartnum[i]=cartnum[i+1];
-		cartlen[i]=cartlen[i+1];
-		stackid[i]=stackid[i+1];
-		artist[i]=artist[i+1];
-		sched_codes[i]=sched_codes[i+1];
-	}
-	itemcounter--;
+  SchedCart *created = new SchedCart(cartnumber, stack_artist, stack_schedcodes);
+
+  if (first_sched_cart != NULL) {
+    first_sched_cart->setPrevious(created);
+    created->setNext(first_sched_cart);
+  } 
+  first_sched_cart = created;
 }
 
-bool SchedCartList::removeIfCode(int itemnumber,QString test_code)
-{
-    QString test = test_code;
-    test+="          ";
-    test=test.left(11);
-
-    if (sched_codes[itemnumber].find(test)!=-1)
-      {
-	for(int i=itemnumber;i<(itemcounter-1);i++)
-	{
-		cartnum[i]=cartnum[i+1];
-		cartlen[i]=cartlen[i+1];
-		stackid[i]=stackid[i+1];
-		artist[i]=artist[i+1];
-		sched_codes[i]=sched_codes[i+1];
-	}
-	itemcounter--;
-        return true;
-      }
-    return false; 
+void SchedCartList::excludeIfCode(QString code) {
+  SchedCart *current = NULL;
+  for (current = first(); current != NULL; current = current->next()) {
+    if (current->hasSchedulerCode(code)) {
+      current->exclude();
+    }
+  }
 }
 
-bool SchedCartList::itemHasCode(int itemnumber,QString test_code)
-{
-    QString test=test_code;
-    test+="          ";
-    test=test.left(11);
-
-    if (sched_codes[itemnumber].find(test)!=-1)
-      return true;
-    else
+bool SchedCartList::allExcluded() {
+  SchedCart *current = NULL;
+  for (current = first_sched_cart; current != NULL; current = current->next()) {
+    if (!current->hasBeenExcluded()) {
       return false;
+    }
+  }
+  return true;
 }
 
-
-void SchedCartList::save(void)
-{
-	savecartnum=new unsigned[itemcounter];
-	savecartlen=new int[itemcounter];
-	savestackid=new int[itemcounter];
-	saveartist=new QString[itemcounter];
-	save_sched_codes=new QString[itemcounter];
-
-	saveitemcounter=itemcounter;	
-	for(int i=0;i<saveitemcounter;i++)
-	{
-		savecartnum[i]=cartnum[i];
-		savecartlen[i]=cartlen[i];
-		savestackid[i]=stackid[i];
-		saveartist[i]=artist[i];
-		save_sched_codes[i]=sched_codes[i];
-	}
+void SchedCartList::clearExclusions() {
+  SchedCart *current = NULL;
+  for (current = first_sched_cart; current != NULL; current = current->next()) {
+    current->clearExclusion();
+  }
 }
 
+void SchedCartList::save() {
+  SchedCart *current = first_sched_cart;
+  SchedCart *excluded = NULL;
 
-void SchedCartList::restore(void)
-{
-	if(itemcounter==0)
-	{
-		for(int i=0;i<saveitemcounter;i++)
-		{
-			cartnum[i]=savecartnum[i];
-			cartlen[i]=savecartlen[i];
-			stackid[i]=savestackid[i];
-			artist[i]=saveartist[i];
-			sched_codes[i]=save_sched_codes[i];
-		}
-		itemcounter=saveitemcounter;	
-	}
-	delete []savecartnum;
-	delete []savecartlen;
-	delete []savestackid;
-	delete []saveartist;
-	delete []save_sched_codes;
+  while (current != NULL) {
+    if (current->hasBeenExcluded()) {
+      excluded = current;
+      current = excluded->next();
+
+      // Remove excluded from the list
+      if (excluded->previous() != NULL) {
+        excluded->previous()->setNext(excluded->next());
+      } else {
+        first_sched_cart = excluded->next();
+      }
+
+      if (excluded->next() != NULL) {
+        excluded->next()->setPrevious(excluded->previous());
+      }
+
+      // Delete excluded
+      delete excluded;
+    } else {
+      current = current->next();
+    }
+  }
 }
 
-
-
-unsigned SchedCartList::getItemCartnumber(int itemnumber)
-{
-	return cartnum[itemnumber];
+void SchedCartList::saveOrBreakRule(QString ruleName, QTime time, QString *errors) {
+  if (!allExcluded()) {
+    save();
+  } else {
+    *errors += time.toString("hh:mm:ss") + QString(" Rule broken: ") + ruleName + QString("\n");
+    clearExclusions();
+  }
 }
 
-int SchedCartList::getItemStackid(int itemnumber)
-{
-	return stackid[itemnumber];
+int SchedCartList::size() {
+  int size = 0;
+  SchedCart *current = NULL;
+  for (current = first_sched_cart; current != NULL; current = current->next()) {
+    size++;
+  }
+  return size;
 }
 
-QString SchedCartList::getItemArtist(int itemnumber)
-{
-	return artist[itemnumber];
+SchedCart* SchedCartList::sample() {
+  int randomPosition = rand() % size();
+  int position = 0;
+  SchedCart *current = NULL;
+  for (current = first_sched_cart; current != NULL; current = current->next()) {
+    if (position == randomPosition) {
+      return current;
+    }
+    position ++;
+  }
+  return NULL;
 }
-
-QString SchedCartList::getItemSchedCodes(int itemnumber)
-{
-	return sched_codes[itemnumber];
-}
-
-int SchedCartList::getItemCartlength(int itemnumber)
-{
-	return cartlen[itemnumber];
-}
-
-
-int SchedCartList::getNumberOfItems(void)
-{
-	return itemcounter;
-}
- 
-
-

--- a/lib/schedcartlist.h
+++ b/lib/schedcartlist.h
@@ -21,43 +21,32 @@
 //
 
 #include <qsqldatabase.h>
-
+#include <qdatetime.h>
+#include <schedcart.h>
 
 #ifndef SCHEDCARTLIST_H
 #define SCHEDCARTLIST_H
 
-
 class SchedCartList
 {
   public:
-   SchedCartList(int listsize);
+   SchedCartList();
    ~SchedCartList();
-   void insertItem(unsigned cartnumber,int cartlength,int stack_id,QString stack_artist,QString stack_schedcodes);
-   void removeItem(int itemnumber);
-   bool removeIfCode(int itemnumber,QString test_code);
-   bool itemHasCode(int itemnumber,QString test_code);
-   unsigned getItemCartnumber(int itemnumber);
-   int getItemCartlength(int itemnumber);
-   int getItemStackid(int itemnumber);
-   QString getItemArtist(int itemnumber);
-   QString getItemSchedCodes(int itemnumber);
-   int getNumberOfItems(void);
-   void save(void);
-   void restore(void);
+
+   void insert(unsigned cartnumber,QString stack_artist,QString stack_schedcodes);
+   SchedCart *first();
+   void excludeIfCode(QString code);
+   void saveOrBreakRule(QString ruleName, QTime time, QString *errors);
+   SchedCart *sample();
    
-  private:
-   int itemcounter;
-   int saveitemcounter;
-   unsigned* cartnum;
-   unsigned* savecartnum;
-   int* cartlen;
-   int* savecartlen;
-   int* stackid;
-   int* savestackid;
-   QString* saveartist;
-   QString* artist;
-   QString* sched_codes;
-   QString* save_sched_codes;
+ private:
+   SchedCart *first_sched_cart;
+
+   bool allExcluded();
+   void clearExclusions();
+   void save();
+   
+   int size();
 };
 
 


### PR DESCRIPTION
We made some benchmarks on rdlogmanager log generation, to especially understand the reasons of the high CPU usage.

In fact ... the slowness is due to a bad choise of data structure in SchedCardList. It uses arrays and the item removal is very expensive, ... but it's the first usage 

This patch is refactoring SchedCardList by using a linked list of SchedCard objects.

The logic is the same, but the generation time has changed :

**Before :**

 ```
rdlogmanager -g -s Grille_A -d 1
441.38s user 0.31s system 94% cpu 7:48.03 total
 ```

**After :**

 ```
rdlogmanager -g -s Grille_A -d 1
10.08s user 0.22s system 29% cpu 34.661 total
 ```

It's 13x faster 

The patch contains 4 other commits to improve SQL queries performed by generateLog (which saves few seconds).

We tested this patch on several customer databases.