### PR TITLE
Patches to add support for dark themes

### DIFF
--- a/lib/rdedit_audio.cpp
+++ b/lib/rdedit_audio.cpp
@@ -169,8 +169,8 @@ RDEditAudio::RDEditAudio(RDCart *cart,QString cut_name,RDCae *cae,RDUser *user,
   edit_play_cursor_button=new RDTransportButton(RDTransportButton::PlayBetween,
 					this,"edit_play_cursor_button");
   edit_play_cursor_button->setGeometry(20,425,65,45);
-  edit_play_cursor_button->
-    setPalette(QPalette(backgroundColor(),QColor(EDITAUDIO_HIGHLIGHT_COLOR)));
+//  edit_play_cursor_button->
+//    setPalette(QPalette(backgroundColor(),QColor(EDITAUDIO_HIGHLIGHT_COLOR)));
   edit_play_cursor_button->setEnabled((edit_card>=0)&&(edit_port>=0));
   connect(edit_play_cursor_button,SIGNAL(clicked()),
 	  this,SLOT(playCursorData()));
@@ -178,8 +178,8 @@ RDEditAudio::RDEditAudio(RDCart *cart,QString cut_name,RDCae *cae,RDUser *user,
   edit_play_start_button=new RDTransportButton(RDTransportButton::Play,
 					this,"edit_play_start_button");
   edit_play_start_button->setGeometry(90,425,65,45);
-  edit_play_start_button->
-    setPalette(QPalette(backgroundColor(),QColor(EDITAUDIO_HIGHLIGHT_COLOR)));
+//  edit_play_start_button->
+//    setPalette(QPalette(backgroundColor(),QColor(EDITAUDIO_HIGHLIGHT_COLOR)));
   edit_play_start_button->setEnabled((edit_card>=0)&&(edit_port>=0));
   connect(edit_play_start_button,SIGNAL(clicked()),
 	  this,SLOT(playStartData()));
@@ -188,8 +188,8 @@ RDEditAudio::RDEditAudio(RDCart *cart,QString cut_name,RDCae *cae,RDUser *user,
 					 this,"edit_pause_button");
   edit_pause_button->setGeometry(160,425,65,45);
   edit_pause_button->setOnColor(QColor(red));
-  edit_pause_button->
-    setPalette(QPalette(backgroundColor(),QColor(EDITAUDIO_HIGHLIGHT_COLOR)));
+//  edit_pause_button->
+//    setPalette(QPalette(backgroundColor(),QColor(EDITAUDIO_HIGHLIGHT_COLOR)));
   edit_pause_button->setEnabled((edit_card>=0)&&(edit_port>=0));
   connect(edit_pause_button,SIGNAL(clicked()),this,SLOT(pauseData()));
 
@@ -198,8 +198,8 @@ RDEditAudio::RDEditAudio(RDCart *cart,QString cut_name,RDCae *cae,RDUser *user,
   edit_stop_button->setGeometry(230,425,65,45);
   edit_stop_button->on();
   edit_stop_button->setOnColor(QColor(red));
-  edit_stop_button->
-    setPalette(QPalette(backgroundColor(),QColor(EDITAUDIO_HIGHLIGHT_COLOR)));
+//  edit_stop_button->
+//    setPalette(QPalette(backgroundColor(),QColor(EDITAUDIO_HIGHLIGHT_COLOR)));
   edit_stop_button->setEnabled((edit_card>=0)&&(edit_port>=0));
   connect(edit_stop_button,SIGNAL(clicked()),this,SLOT(stopData()));
 
@@ -207,8 +207,8 @@ RDEditAudio::RDEditAudio(RDCart *cart,QString cut_name,RDCae *cae,RDUser *user,
 					this,"edit_loop_button");
   edit_loop_button->setGeometry(300,425,65,45);
   edit_loop_button->off();
-  edit_loop_button->
-    setPalette(QPalette(backgroundColor(),QColor(EDITAUDIO_HIGHLIGHT_COLOR)));
+//  edit_loop_button->
+//    setPalette(QPalette(backgroundColor(),QColor(EDITAUDIO_HIGHLIGHT_COLOR)));
   edit_loop_button->setEnabled((edit_card>=0)&&(edit_port>=0));
   connect(edit_loop_button,SIGNAL(clicked()),this,SLOT(loopData()));
 
@@ -714,11 +714,11 @@ RDEditAudio::RDEditAudio(RDCart *cart,QString cut_name,RDCae *cae,RDUser *user,
   // Segue Fade Box
   //
   edit_overlap_box=new QCheckBox(this,"edit_overlap_box");
-  edit_overlap_box->setGeometry(570,510,15,15);
+  edit_overlap_box->setGeometry(570,515,15,15);
   label=new QLabel(edit_overlap_box,tr("No Fade on Segue Out"),
 		   this,"label");
-  label->setGeometry(590,508,130,20);
-  label->setFont(button_font);
+  label->setGeometry(590,513,130,20);
+  label->setFont(small_font);
   label->setAlignment(AlignLeft|AlignVCenter|ShowPrefix);
   
   //

--- a/lib/rdslotbox.cpp
+++ b/lib/rdslotbox.cpp
@@ -98,6 +98,12 @@ RDSlotBox::RDSlotBox(RDPlayDeck *deck,RDAirPlayConf *conf,QWidget *parent)
   line_timescale_palette.setColor(QPalette::Inactive,QColorGroup::Foreground,
 				  QColor(LABELBOX_TIMESCALE_COLOR));
 
+  line_text_palette=palette();
+  line_text_palette.setColor(QPalette::Active,QColorGroup::Foreground,
+				  QColor(black));
+  line_text_palette.setColor(QPalette::Inactive,QColorGroup::Foreground,
+				  QColor(black));
+
   //
   // Audio Meter
   //
@@ -557,16 +563,26 @@ void RDSlotBox::SetColor(QColor color)
 {
   setBackgroundColor(color);
   line_cart_label->setBackgroundColor(color);
+  line_cart_label->setPalette(line_text_palette);
   line_cut_label->setBackgroundColor(color);
+  line_cut_label->setPalette(line_text_palette);
   line_group_label->setBackgroundColor(color);
   line_title_label->setBackgroundColor(color);
+  line_title_label->setPalette(line_text_palette);
   line_description_label->setBackgroundColor(color);
+  line_description_label->setPalette(line_text_palette);
   line_artist_label->setBackgroundColor(color);
+  line_artist_label->setPalette(line_text_palette);
   line_outcue_label->setBackgroundColor(color);
+  line_outcue_label->setPalette(line_text_palette);
   line_length_label->setBackgroundColor(color);
+  line_length_label->setPalette(line_text_palette);
   line_talktime_label->setBackgroundColor(color);
+  line_talktime_label->setPalette(line_text_palette);
   line_up_label->setBackgroundColor(color);
-  line_position_bar->setBackgroundColor(QColor(Qt::lightGray));
+  line_up_label->setPalette(line_text_palette);
+  line_position_bar->setBackgroundColor(QColor(lightGray));
   line_down_label->setBackgroundColor(color);
+  line_down_label->setPalette(line_text_palette);
   line_icon_label->setBackgroundColor(color);
 }

--- a/lib/rdslotbox.h
+++ b/lib/rdslotbox.h
@@ -106,6 +106,7 @@ class RDSlotBox : public QWidget
   QPalette line_time_palette;
   QPalette line_hard_palette;
   QPalette line_timescale_palette;
+  QPalette line_text_palette;
   RDLogLine::Type line_type;
   QPixmap *line_playout_map;
   QPixmap *line_macro_map;

--- a/rdairplay/list_log.cpp
+++ b/rdairplay/list_log.cpp
@@ -89,13 +89,18 @@ ListLog::ListLog(LogPlay *log,int id,bool allow_pause,
   //
   // Create Palettes
   //
+  QColor system_button_text_color = palette().active().buttonText();
+  QColor system_button_color = palette().active().button();
+  QColor system_mid_color = colorGroup().mid();
   list_from_color=
-    QPalette(QColor(BUTTON_FROM_BACKGROUND_COLOR),QColor(lightGray));
+    QPalette(QColor(BUTTON_FROM_BACKGROUND_COLOR),QColor(system_mid_color));
+ //   QPalette(QColor(BUTTON_FROM_BACKGROUND_COLOR),QColor(lightGray));
   list_from_color.
     setColor(QColorGroup::ButtonText,QColor(BUTTON_FROM_TEXT_COLOR));
 
   list_to_color=
-    QPalette(QColor(BUTTON_TO_BACKGROUND_COLOR),QColor(lightGray));
+    QPalette(QColor(BUTTON_TO_BACKGROUND_COLOR),QColor(system_mid_color));
+  //  QPalette(QColor(BUTTON_TO_BACKGROUND_COLOR),QColor(lightGray));
   list_to_color.
     setColor(QColorGroup::ButtonText,QColor(BUTTON_TO_TEXT_COLOR));
   list_list_to_color=palette();
@@ -123,14 +128,33 @@ ListLog::ListLog(LogPlay *log,int id,bool allow_pause,
   list_scroll_color[0].setColor(QPalette::Active,QColorGroup::Button,
 			BUTTON_LOG_ACTIVE_BACKGROUND_COLOR);
   list_scroll_color[0].setColor(QPalette::Active,QColorGroup::Background,
-			lightGray);
+			system_mid_color);
+//			lightGray);
   list_scroll_color[0].setColor(QPalette::Inactive,QColorGroup::ButtonText,
 			BUTTON_LOG_ACTIVE_TEXT_COLOR);
   list_scroll_color[0].setColor(QPalette::Inactive,QColorGroup::Button,
 			BUTTON_LOG_ACTIVE_BACKGROUND_COLOR);
   list_scroll_color[0].setColor(QPalette::Inactive,QColorGroup::Background,
-			lightGray);
-  list_scroll_color[1]=QPalette(backgroundColor(),lightGray);
+			system_mid_color);
+//			lightGray);
+//  list_scroll_color[1]=QPalette(backgroundColor(),QColor(system_button_text_color));
+  list_scroll_color[1]=palette();
+  list_scroll_color[1].setColor(QPalette::Active,QColorGroup::ButtonText,
+                       system_button_text_color);
+  list_scroll_color[1].setColor(QPalette::Active,QColorGroup::Button,
+//                       backgroundColor());
+                       system_button_color);
+  list_scroll_color[1].setColor(QPalette::Active,QColorGroup::Background,
+			system_mid_color);
+//                       lightGray);
+  list_scroll_color[1].setColor(QPalette::Inactive,QColorGroup::ButtonText,
+                       system_button_text_color);
+  list_scroll_color[1].setColor(QPalette::Inactive,QColorGroup::Button,
+//                       backgroundColor());
+                       system_button_color);
+  list_scroll_color[1].setColor(QPalette::Inactive,QColorGroup::Background,
+			system_mid_color);
+//                       lightGray);
 
   //
   // Hour Selector
@@ -218,7 +242,8 @@ ListLog::ListLog(LogPlay *log,int id,bool allow_pause,
   label->setGeometry(372,sizeHint().height()-120,75,20);
   label->setFont(label_font);
   label->setAlignment(AlignCenter);  
-  label->setBackgroundColor(QColor(lightGray));
+  label->setBackgroundColor(QColor(system_mid_color));
+//  label->setBackgroundColor(QColor(lightGray));
   if(!rdairplay_conf->showCounters()) {
     label->hide();
   }
@@ -232,7 +257,8 @@ ListLog::ListLog(LogPlay *log,int id,bool allow_pause,
   list_stoptime_label->setGeometry(337,sizeHint().height()-100,65,18);
   list_stoptime_label->setFont(label_font);
   list_stoptime_label->setAlignment(AlignRight|AlignVCenter);  
-  list_stoptime_label->setBackgroundColor(QColor(lightGray));
+  list_stoptime_label->setBackgroundColor(QColor(system_mid_color));
+//  list_stoptime_label->setBackgroundColor(QColor(lightGray));
   if(!rdairplay_conf->showCounters()) {
     list_stoptime_edit->hide();
     list_stoptime_label->hide();
@@ -243,14 +269,15 @@ ListLog::ListLog(LogPlay *log,int id,bool allow_pause,
   //
   list_endtime_edit=new QLineEdit(this,"list_endtime_edit");
   list_endtime_edit->setGeometry(407,sizeHint().height()-80,70,18);
-  label=new QLabel(list_endtime_edit,tr("Log End:"),this);
-  label->setGeometry(337,sizeHint().height()-80,65,18);
-  label->setFont(label_font);
-  label->setAlignment(AlignRight|AlignVCenter);  
-  label->setBackgroundColor(QColor(lightGray));
+  list_endtime_label=new QLabel(list_endtime_edit,tr("Log End:"),this);
+  list_endtime_label->setGeometry(337,sizeHint().height()-80,65,18);
+  list_endtime_label->setFont(label_font);
+  list_endtime_label->setAlignment(AlignRight|AlignVCenter);  
+  list_endtime_label->setBackgroundColor(QColor(system_mid_color));
+//  list_endtime_label->setBackgroundColor(QColor(lightGray));
   if(!rdairplay_conf->showCounters()) {
     list_endtime_edit->hide();
-    label->hide();
+    list_endtime_label->hide();
   }
 
   //
@@ -259,7 +286,8 @@ ListLog::ListLog(LogPlay *log,int id,bool allow_pause,
   list_take_button=new QPushButton(this,"list_take_button");
   list_take_button->setGeometry(10,sizeHint().height()-55,80,50);
   list_take_button->setFont(font);
-  list_take_button->setPalette(QPalette(backgroundColor(),QColor(lightGray)));
+  list_take_button->setPalette(QPalette(QColor(system_button_color),QColor(system_mid_color)));
+//  list_take_button->setPalette(QPalette(backgroundColor(),QColor(lightGray)));
   list_take_button->setText(tr("Select"));
   list_take_button->setFocusPolicy(QWidget::NoFocus);
   connect(list_take_button,SIGNAL(clicked()),this,SLOT(takeButtonData()));
@@ -271,7 +299,8 @@ ListLog::ListLog(LogPlay *log,int id,bool allow_pause,
   list_head_button=new QPushButton(this,"list_head_button");
   list_head_button->setGeometry(10,sizeHint().height()-113,80,50);
   list_head_button->setFont(font);
-  list_head_button->setPalette(QPalette(backgroundColor(),QColor(lightGray)));
+  list_head_button->setPalette(QPalette(QColor(system_button_color),QColor(system_mid_color)));
+//  list_head_button->setPalette(QPalette(backgroundColor(),QColor(lightGray)));
   list_head_button->setText(tr("Audition\nHead"));
   list_head_button->setFocusPolicy(QWidget::NoFocus);
   connect(list_head_button,SIGNAL(clicked()),this,SLOT(headButtonData()));
@@ -285,7 +314,8 @@ ListLog::ListLog(LogPlay *log,int id,bool allow_pause,
   list_tail_button=new QPushButton(this,"list_tail_button");
   list_tail_button->setGeometry(90,sizeHint().height()-113,80,50);
   list_tail_button->setFont(font);
-  list_tail_button->setPalette(QPalette(backgroundColor(),QColor(lightGray)));
+  list_tail_button->setPalette(QPalette(QColor(system_button_color),QColor(system_mid_color)));
+//  list_tail_button->setPalette(QPalette(backgroundColor(),QColor(lightGray)));
   list_tail_button->setText(tr("Audition\nTail"));
   list_tail_button->setFocusPolicy(QWidget::NoFocus);
   connect(list_tail_button,SIGNAL(clicked()),this,SLOT(tailButtonData()));
@@ -299,7 +329,8 @@ ListLog::ListLog(LogPlay *log,int id,bool allow_pause,
   list_play_button=new QPushButton(this,"list_play_button");
   list_play_button->setGeometry(10,sizeHint().height()-55,80,50);
   list_play_button->setFont(font);
-  list_play_button->setPalette(QPalette(backgroundColor(),QColor(lightGray)));
+  list_play_button->setPalette(QPalette(QColor(system_button_color),QColor(system_mid_color)));
+//  list_play_button->setPalette(QPalette(backgroundColor(),QColor(lightGray)));
   list_play_button->setText(tr("Start"));
   list_play_button->setDisabled(true);
   list_play_button->setFocusPolicy(QWidget::NoFocus);
@@ -311,8 +342,9 @@ ListLog::ListLog(LogPlay *log,int id,bool allow_pause,
   list_next_button=new QPushButton(this,"list_next_button");
   list_next_button->setGeometry(90,sizeHint().height()-55,80,50);
   list_next_button->setFont(font);
-  list_next_button->setPalette(QPalette(backgroundColor(),
-					  QColor(lightGray)));
+  list_next_button->setPalette(QPalette(QColor(system_button_color),QColor(system_mid_color)));
+//  list_next_button->setPalette(QPalette(backgroundColor(),
+//					  QColor(lightGray)));
   list_next_button->setText(tr("Make\nNext"));
   list_next_button->setDisabled(true);
   list_next_button->setFocusPolicy(QWidget::NoFocus);
@@ -324,8 +356,9 @@ ListLog::ListLog(LogPlay *log,int id,bool allow_pause,
   list_modify_button=new QPushButton(this,"list_modify_button");
   list_modify_button->setGeometry(170,sizeHint().height()-55,80,50);
   list_modify_button->setFont(font);
-  list_modify_button->setPalette(QPalette(backgroundColor(),
-					  QColor(lightGray)));
+  list_modify_button->setPalette(QPalette(QColor(system_button_color),QColor(system_mid_color)));
+//  list_modify_button->setPalette(QPalette(backgroundColor(),
+//					  QColor(lightGray)));
   list_modify_button->setText(tr("Modify"));
   list_modify_button->setDisabled(true);
   list_modify_button->setFocusPolicy(QWidget::NoFocus);
@@ -337,8 +370,9 @@ ListLog::ListLog(LogPlay *log,int id,bool allow_pause,
   list_scroll_button=new QPushButton(this,"list_scroll_button");
   list_scroll_button->setGeometry(250,sizeHint().height()-55,80,50);
   list_scroll_button->setFont(font);
-  list_scroll_button->setPalette(QPalette(backgroundColor(),
-					  QColor(lightGray)));
+  list_scroll_button->setPalette(QPalette(QColor(system_button_color),QColor(system_mid_color)));
+//  list_scroll_button->setPalette(QPalette(backgroundColor(),
+//					  QColor(lightGray)));
   list_scroll_button->setText(tr("Scroll"));
   list_scroll_button->setFocusPolicy(QWidget::NoFocus);
   connect(list_scroll_button,SIGNAL(clicked()),this,SLOT(scrollButtonData()));
@@ -350,8 +384,9 @@ ListLog::ListLog(LogPlay *log,int id,bool allow_pause,
   list_refresh_button=new QPushButton(this,"list_refresh_button");
   list_refresh_button->setGeometry(330,sizeHint().height()-55,80,50);
   list_refresh_button->setFont(font);
-  list_refresh_button->
-    setPalette(QPalette(backgroundColor(),QColor(lightGray)));
+  list_refresh_button->setPalette(QPalette(QColor(system_button_color),QColor(system_mid_color)));
+//  list_refresh_button->
+//    setPalette(QPalette(backgroundColor(),QColor(lightGray)));
   list_refresh_button->setText(tr("Refresh\nLog"));
   list_refresh_button->setDisabled(true);
   list_refresh_button->setFocusPolicy(QWidget::NoFocus);
@@ -365,7 +400,8 @@ ListLog::ListLog(LogPlay *log,int id,bool allow_pause,
   list_load_button->setGeometry(sizeHint().width()-90,sizeHint().height()-55,
 				80,50);
   list_load_button->setFont(font);
-  list_load_button->setPalette(QPalette(backgroundColor(),QColor(lightGray)));
+  list_load_button->setPalette(QPalette(QColor(system_button_color),QColor(system_mid_color)));
+//  list_load_button->setPalette(QPalette(backgroundColor(),QColor(lightGray)));
   list_load_button->setText(tr("Select\nLog"));
   list_load_button->setFocusPolicy(QWidget::NoFocus);
   connect(list_load_button,SIGNAL(clicked()),this,SLOT(loadButtonData()));
@@ -397,7 +433,8 @@ ListLog::ListLog(LogPlay *log,int id,bool allow_pause,
   connect(list_log,SIGNAL(auditionStopped(int)),
 	  this,SLOT(auditionStoppedData(int)));
 
-  setBackgroundColor(QColor(lightGray));
+  setBackgroundColor(QColor(system_mid_color));
+//  setBackgroundColor(QColor(lightGray));
 
   RefreshList();
   UpdateTimes();

--- a/rdairplay/list_log.h
+++ b/rdairplay/list_log.h
@@ -118,6 +118,7 @@ class ListLog : public QWidget
   RDAirPlayConf::ActionMode list_action_mode;
   ListLog::PlayButtonMode list_playbutton_mode;
   EditEvent *list_event_edit;
+  QLabel *list_endtime_label;
   QLineEdit *list_endtime_edit;
   QLabel *list_stoptime_label;
   QLineEdit *list_stoptime_edit;

--- a/rdairplay/loglinebox.cpp
+++ b/rdairplay/loglinebox.cpp
@@ -131,6 +131,12 @@ LogLineBox::LogLineBox(RDAirPlayConf *conf,QWidget *parent,const char *name)
   line_transition_palette.setColor(QPalette::Inactive,QColorGroup::Foreground,
 				  QColor(RD_CUSTOM_TRANSITION_COLOR));
 
+  line_text_palette=palette();
+  line_text_palette.setColor(QPalette::Active,QColorGroup::Foreground,
+				  QColor(black));
+  line_text_palette.setColor(QPalette::Inactive,QColorGroup::Foreground,
+				  QColor(black));
+
   //
   // Count Up
   //
@@ -846,20 +852,33 @@ void LogLineBox::SetColor(QColor color)
   setBackgroundColor(color);
   //  color=Qt::red;
   line_cart_label->setBackgroundColor(color);
+  line_cart_label->setPalette(line_text_palette);
   line_cut_label->setBackgroundColor(color);
+  line_cut_label->setPalette(line_text_palette);
   line_group_label->setBackgroundColor(color);
   line_trans_label->setBackgroundColor(color);
+  line_trans_label->setPalette(line_text_palette);
   line_title_label->setBackgroundColor(color);
+  line_title_label->setPalette(line_text_palette);
   line_description_label->setBackgroundColor(color);
+  line_description_label->setPalette(line_text_palette);
   line_artist_label->setBackgroundColor(color);
+  line_artist_label->setPalette(line_text_palette);
   line_outcue_label->setBackgroundColor(color);
+  line_outcue_label->setPalette(line_text_palette);
   line_time_label->setBackgroundColor(color);
+  line_time_label->setPalette(line_text_palette);
   line_length_label->setBackgroundColor(color);
+  line_length_label->setPalette(line_text_palette);
   line_talktime_label->setBackgroundColor(color);
+  line_talktime_label->setPalette(line_text_palette);
   line_up_label->setBackgroundColor(color);
+  line_up_label->setPalette(line_text_palette);
   line_position_bar->setBackgroundColor(QColor(lightGray));
   line_down_label->setBackgroundColor(color);
+  line_down_label->setPalette(line_text_palette);
   line_comment_label->setBackgroundColor(color);
+  line_comment_label->setPalette(line_text_palette);
   line_icon_label->setBackgroundColor(color);
 }
 

--- a/rdairplay/loglinebox.h
+++ b/rdairplay/loglinebox.h
@@ -127,6 +127,7 @@ class LogLineBox : public QWidget
   QPalette line_hard_palette;
   QPalette line_timescale_palette;
   QPalette line_transition_palette;
+  QPalette line_text_palette;
   RDLogLine::TransType line_next_type;
   RDAirPlayConf::TimeMode line_time_mode;
   RDLogLine::Type line_type;

--- a/rdairplay/post_counter.cpp
+++ b/rdairplay/post_counter.cpp
@@ -127,6 +127,7 @@ void PostCounter::keyPressEvent(QKeyEvent *e)
 void PostCounter::UpdateDisplay()
 {
   QColor color=backgroundColor();
+  QColor system_button_text_color=palette().active().buttonText();
   QString str;
   QString point;
   QString state;
@@ -160,6 +161,7 @@ void PostCounter::UpdateDisplay()
 	  color=POSTPOINT_ONTIME_COLOR;
 	}
       }
+      system_button_text_color = color1;
     }
     else {
       state="--------";
@@ -175,7 +177,8 @@ void PostCounter::UpdateDisplay()
   QPainter *p=new QPainter(&pix);
   p->fillRect(0,0,sizeHint().width(),sizeHint().height(),color);
   //  p->eraseRect(0,0,sizeHint().width(),sizeHint().height());
-  p->setPen(color1);
+  //p->setPen(color1);
+  p->setPen(QColor(system_button_text_color));
   p->setFont(post_small_font);
   p->drawText((sizeHint().width()-p->
 	       fontMetrics().width(point))/2,22,point);

--- a/rdairplay/stop_counter.cpp
+++ b/rdairplay/stop_counter.cpp
@@ -131,6 +131,7 @@ void StopCounter::tickCounter()
 void StopCounter::UpdateTime()
 {
   QString text;
+  QColor system_button_text_color = palette().active().buttonText();
   int msecs=QTime::currentTime().
     addMSecs(rdstation_conf->timeOffset()).msecsTo(stop_time);
 
@@ -143,7 +144,8 @@ void StopCounter::UpdateTime()
 	  p->fillRect(0,0,sizeHint().width(),sizeHint().height(),
 		      backgroundColor());
 	  //p->eraseRect(0,0,sizeHint().width(),sizeHint().height());
-	  p->setPen(QColor(color1));
+          //p->setPen(QColor(color1));
+          p->setPen(QColor(system_button_text_color));
 	  p->setFont(stop_text_font);
 	  p->drawText((sizeHint().width()-p->fontMetrics().width(stop_text))/2,22,
 		      stop_text);

--- a/rdairplay/wall_clock.cpp
+++ b/rdairplay/wall_clock.cpp
@@ -21,6 +21,7 @@
 //
 
 #include <qpainter.h>
+#include <qpalette.h>
 #include <qpixmap.h>
 #include <qdatetime.h>
 #include <qfontmetrics.h>
@@ -109,6 +110,7 @@ void WallClock::tickClock()
 {
   static QString date;
   QString accum;
+  QColor system_button_text_color = palette().active().buttonText();
   static QPixmap *pix=new QPixmap(sizeHint().width(),sizeHint().height());
   static bool synced=true;
 
@@ -152,13 +154,15 @@ void WallClock::tickClock()
   QPainter p(pix);
   if(flash_state) {
     p.fillRect(0,0,width(),height(),BUTTON_TIME_SYNC_LOST_COLOR);
+    p.setPen(QColor(color1));
   }
   else {
     p.fillRect(0,0,width(),height(),backgroundColor());
   }
   //p.eraseRect(0,0,width(),height());
-  p.setPen(color1);
-  p.setBrush(color1);
+//  p.setPen(color1);
+//  p.setBrush(color1);
+  p.setPen(QColor(system_button_text_color));
   p.setFont(label_font);
   p.drawText((sizeHint().width()-p.fontMetrics().width(date))/2,22,date);
   p.setFont(time_font);

--- a/rdairplay/wall_clock.cpp
+++ b/rdairplay/wall_clock.cpp
@@ -158,11 +158,11 @@ void WallClock::tickClock()
   }
   else {
     p.fillRect(0,0,width(),height(),backgroundColor());
+    p.setPen(QColor(system_button_text_color));
   }
   //p.eraseRect(0,0,width(),height());
 //  p.setPen(color1);
 //  p.setBrush(color1);
-  p.setPen(QColor(system_button_text_color));
   p.setFont(label_font);
   p.drawText((sizeHint().width()-p.fontMetrics().width(date))/2,22,date);
   p.setFont(time_font);

--- a/rdlibrary/audio_cart.cpp
+++ b/rdlibrary/audio_cart.cpp
@@ -79,6 +79,7 @@ AudioCart::AudioCart(AudioControls *controls,RDCart *cart,QString *path,
   button_font.setPixelSize(12);
   QFont line_edit_font=QFont("Helvetica",12,QFont::Normal);
   line_edit_font.setPixelSize(12);
+  QColor system_button_text_color = palette().active().buttonText();
 
   //
   // Progress Dialog
@@ -185,7 +186,8 @@ AudioCart::AudioCart(AudioControls *controls,RDCart *cart,QString *path,
   QPainter *p=new QPainter(pix);
   QFontMetrics *m=new QFontMetrics(button_font);
   p->fillRect(0,0,80,50,palette().color(QPalette::Active,QColorGroup::Button));
-  p->setPen(QColor(color1));
+  //p->setPen(QColor(color1));
+  p->setPen(QColor(system_button_text_color));
   p->setFont(button_font);
   p->drawText((80-m->width(tr("Cut Info")))/2,20,tr("Cut Info"));
   p->moveTo(10,24);
@@ -229,7 +231,8 @@ AudioCart::AudioCart(AudioControls *controls,RDCart *cart,QString *path,
   p=new QPainter(pix);
   m=new QFontMetrics(button_font);
   p->fillRect(0,0,80,50,palette().color(QPalette::Active,QColorGroup::Button));
-  p->setPen(QColor(color1));
+  //p->setPen(QColor(color1));
+  p->setPen(QColor(system_button_text_color));
   p->setFont(button_font);
   p->drawText((80-m->width(tr("Import")))/2,20,tr("Import"));
   p->moveTo(10,24);

--- a/rdlogedit/edit_log.cpp
+++ b/rdlogedit/edit_log.cpp
@@ -71,6 +71,8 @@ EditLog::EditLog(QString logname,vector<RDLogLine> *clipboard,
   QString sql;
   RDSqlQuery *q;
   QStringList services_list;
+  QColor system_mid_color = colorGroup().mid();
+  QColor system_button_color = palette().active().button();
 
   edit_logname=logname;
   edit_clipboard=clipboard;
@@ -144,12 +146,14 @@ EditLog::EditLog(QString logname,vector<RDLogLine> *clipboard,
   // Log Name
   //
   edit_logname_label=new QLabel(logname,this,"edit_logname_label");
-  edit_logname_label->setBackgroundColor(QColor(lightGray));
+  edit_logname_label->setBackgroundColor(QColor(system_mid_color));
+//  edit_logname_label->setBackgroundColor(QColor(lightGray));
   edit_logname_label->setAlignment(AlignLeft|AlignVCenter);
   edit_logname_label->setFont(title_font);
   edit_logname_label_label=new QLabel(tr("Log Name:"),
 				      this,"edit_logname_label_label");
-  edit_logname_label_label->setBackgroundColor(QColor(lightGray));
+  edit_logname_label_label->setBackgroundColor(QColor(system_mid_color));
+//  edit_logname_label_label->setBackgroundColor(QColor(lightGray));
   edit_logname_label_label->setFont(label_font);
   edit_logname_label_label->setAlignment(AlignRight|AlignVCenter);
 
@@ -157,12 +161,14 @@ EditLog::EditLog(QString logname,vector<RDLogLine> *clipboard,
   // Track Counts
   //
   edit_track_label=new QLabel(this,"edit_track_label");
-  edit_track_label->setBackgroundColor(QColor(lightGray));
+  edit_track_label->setBackgroundColor(QColor(system_mid_color));
+//  edit_track_label->setBackgroundColor(QColor(lightGray));
   edit_track_label->setAlignment(AlignLeft|AlignVCenter);
   edit_track_label->setFont(title_font);
   edit_track_label_label=new QLabel(tr("Tracks:"),
 				      this,"edit_track_label_label");
-  edit_track_label_label->setBackgroundColor(QColor(lightGray));
+  edit_track_label_label->setBackgroundColor(QColor(system_mid_color));
+//  edit_track_label_label->setBackgroundColor(QColor(lightGray));
   edit_track_label_label->setFont(label_font);
   edit_track_label_label->setAlignment(AlignRight|AlignVCenter);
 
@@ -172,12 +178,14 @@ EditLog::EditLog(QString logname,vector<RDLogLine> *clipboard,
   edit_origin_label=new QLabel(edit_log->originUser()+QString(" - ")+
 		  edit_log->originDatetime().toString("MM/dd/yyyy - hh:mm:ss"),
 	          this,"edit_origin_label");
-  edit_origin_label->setBackgroundColor(QColor(lightGray));
+  edit_origin_label->setBackgroundColor(QColor(system_mid_color));
+//  edit_origin_label->setBackgroundColor(QColor(lightGray));
   edit_origin_label->setAlignment(AlignLeft|AlignVCenter);
   edit_origin_label->setFont(title_font);
   edit_origin_label_label=new QLabel(tr("Origin:"),
 				     this,"edit_origin_label_label");
-  edit_origin_label_label->setBackgroundColor(QColor(lightGray));
+  edit_origin_label_label->setBackgroundColor(QColor(system_mid_color));
+//  edit_origin_label_label->setBackgroundColor(QColor(lightGray));
   edit_origin_label_label->setFont(label_font);
   edit_origin_label_label->setAlignment(AlignRight|AlignVCenter);
 
@@ -362,7 +370,8 @@ EditLog::EditLog(QString logname,vector<RDLogLine> *clipboard,
   //  Insert Cart Button
   //
   edit_cart_button=new QPushButton(this,"edit_cart_button");
-  edit_cart_button->setPalette(QPalette(backgroundColor(),QColor(lightGray)));
+  edit_cart_button->setPalette(QPalette(QColor(system_button_color),QColor(system_mid_color)));
+//  edit_cart_button->setPalette(QPalette(backgroundColor(),QColor(lightGray)));
   edit_cart_button->setFont(button_font);
   edit_cart_button->setText(tr("Insert\nCart"));
   connect(edit_cart_button,SIGNAL(clicked()),
@@ -372,8 +381,9 @@ EditLog::EditLog(QString logname,vector<RDLogLine> *clipboard,
   //  Insert Marker Button
   //
   edit_marker_button=new QPushButton(this,"edit_marker_button");
-  edit_marker_button->
-    setPalette(QPalette(backgroundColor(),QColor(lightGray)));
+  edit_marker_button->setPalette(QPalette(QColor(system_button_color),QColor(system_mid_color)));
+//  edit_marker_button->
+//    setPalette(QPalette(backgroundColor(),QColor(lightGray)));
   edit_marker_button->setFont(button_font);
   edit_marker_button->setText(tr("Insert\nMeta"));
   connect(edit_marker_button,SIGNAL(clicked()),
@@ -383,7 +393,8 @@ EditLog::EditLog(QString logname,vector<RDLogLine> *clipboard,
   //  Edit Button
   //
   edit_edit_button=new QPushButton(this,"edit_edit_button");
-  edit_edit_button->setPalette(QPalette(backgroundColor(),QColor(lightGray)));
+  edit_edit_button->setPalette(QPalette(QColor(system_button_color),QColor(system_mid_color)));
+//  edit_edit_button->setPalette(QPalette(backgroundColor(),QColor(lightGray)));
   edit_edit_button->setFont(button_font);
   edit_edit_button->setText(tr("Edit"));
   connect(edit_edit_button,SIGNAL(clicked()),this,SLOT(editButtonData()));
@@ -392,8 +403,9 @@ EditLog::EditLog(QString logname,vector<RDLogLine> *clipboard,
   //  Delete Button
   //
   edit_delete_button=new QPushButton(this,"edit_delete_button");
-  edit_delete_button->
-    setPalette(QPalette(backgroundColor(),QColor(lightGray)));
+  edit_delete_button->setPalette(QPalette(QColor(system_button_color),QColor(system_mid_color)));
+//  edit_delete_button->
+//    setPalette(QPalette(backgroundColor(),QColor(lightGray)));
   edit_delete_button->setFont(button_font);
   edit_delete_button->setText(tr("Delete"));
   connect(edit_delete_button,SIGNAL(clicked()),this,SLOT(deleteButtonData()));
@@ -403,7 +415,8 @@ EditLog::EditLog(QString logname,vector<RDLogLine> *clipboard,
   //
   edit_up_button=new RDTransportButton(RDTransportButton::Up,
 				      this,"delete_button");
-  edit_up_button->setPalette(QPalette(backgroundColor(),QColor(lightGray)));
+  edit_up_button->setPalette(QPalette(QColor(system_button_color),QColor(system_mid_color)));
+//  edit_up_button->setPalette(QPalette(backgroundColor(),QColor(lightGray)));
   connect(edit_up_button,SIGNAL(clicked()),this,SLOT(upButtonData()));
 
   //
@@ -411,14 +424,16 @@ EditLog::EditLog(QString logname,vector<RDLogLine> *clipboard,
   //
   edit_down_button=new RDTransportButton(RDTransportButton::Down,
 					this,"delete_button");
-  edit_down_button->setPalette(QPalette(backgroundColor(),QColor(lightGray)));
+  edit_down_button->setPalette(QPalette(QColor(system_button_color),QColor(system_mid_color)));
+//  edit_down_button->setPalette(QPalette(backgroundColor(),QColor(lightGray)));
   connect(edit_down_button,SIGNAL(clicked()),this,SLOT(downButtonData()));
 
   //
   //  Cut Button
   //
   edit_cut_button=new QPushButton(this,"edit_cut_button");
-  edit_cut_button->setPalette(QPalette(backgroundColor(),QColor(lightGray)));
+  edit_cut_button->setPalette(QPalette(QColor(system_button_color),QColor(system_mid_color)));
+//  edit_cut_button->setPalette(QPalette(backgroundColor(),QColor(lightGray)));
   edit_cut_button->setFont(button_font);
   edit_cut_button->setText(tr("Cut"));
   connect(edit_cut_button,SIGNAL(clicked()),this,SLOT(cutButtonData()));
@@ -427,7 +442,8 @@ EditLog::EditLog(QString logname,vector<RDLogLine> *clipboard,
   //  Copy Button
   //
   edit_copy_button=new QPushButton(this,"edit_copy_button");
-  edit_copy_button->setPalette(QPalette(backgroundColor(),QColor(lightGray)));
+  edit_copy_button->setPalette(QPalette(QColor(system_button_color),QColor(system_mid_color)));
+//  edit_copy_button->setPalette(QPalette(backgroundColor(),QColor(lightGray)));
   edit_copy_button->setFont(button_font);
   edit_copy_button->setText(tr("Copy"));
   connect(edit_copy_button,SIGNAL(clicked()),this,SLOT(copyButtonData()));
@@ -436,7 +452,8 @@ EditLog::EditLog(QString logname,vector<RDLogLine> *clipboard,
   //  Paste Button
   //
   edit_paste_button=new QPushButton(this,"edit_paste_button");
-  edit_paste_button->setPalette(QPalette(backgroundColor(),QColor(lightGray)));
+  edit_paste_button->setPalette(QPalette(QColor(system_button_color),QColor(system_mid_color)));
+//  edit_paste_button->setPalette(QPalette(backgroundColor(),QColor(lightGray)));
   edit_paste_button->setFont(button_font);
   edit_paste_button->setText(tr("Paste"));
   connect(edit_paste_button,SIGNAL(clicked()),this,SLOT(pasteButtonData()));
@@ -474,10 +491,10 @@ EditLog::EditLog(QString logname,vector<RDLogLine> *clipboard,
   edit_player=
     new RDSimplePlayer(rdcae,rdripc,edit_output_card,edit_output_port,
 		       edit_start_macro,edit_end_macro,this,"edit_player");
-  edit_player->playButton()->
-    setPalette(QPalette(backgroundColor(),QColor(lightGray)));
-  edit_player->stopButton()->
-    setPalette(QPalette(backgroundColor(),QColor(lightGray)));
+//  edit_player->playButton()->
+//    setPalette(QPalette(backgroundColor(),QColor(lightGray)));
+//  edit_player->stopButton()->
+//    setPalette(QPalette(backgroundColor(),QColor(lightGray)));
   edit_player->stopButton()->setOnColor(red);
 #endif  // WIN32
 
@@ -1263,10 +1280,13 @@ void EditLog::resizeEvent(QResizeEvent *e)
 
 void EditLog::paintEvent(QPaintEvent *e)
 {
+  QColor system_mid_color = colorGroup().mid();
   QPainter *p=new QPainter(this);
-  p->fillRect(60,8,size().width()-120,24,QColor(lightGray));
+  p->fillRect(60,8,size().width()-120,24,QColor(system_mid_color));
+//  p->fillRect(60,8,size().width()-120,24,QColor(lightGray));
   p->fillRect(9,size().height()-130,size().width()-20,60,
-	      QColor(lightGray));
+	      QColor(system_mid_color));
+//	      QColor(lightGray));
 
   p->setPen(black);
   p->setBrush(black);

--- a/rdlogedit/voice_tracker.cpp
+++ b/rdlogedit/voice_tracker.cpp
@@ -136,6 +136,8 @@ VoiceTracker::VoiceTracker(const QString &logname,QString *import_path,
   track_start_palette=QPalette(TRACKER_START_BUTTON_COLOR,backgroundColor());
   track_done_palette=QPalette(TRACKER_DONE_BUTTON_COLOR,backgroundColor());
   track_abort_palette=QPalette(TRACKER_ABORT_BUTTON_COLOR,backgroundColor());
+  QColor system_mid_color = colorGroup().mid();
+  QColor system_button_color = palette().active().button();
 
   //
   // Create Track and Target Region
@@ -342,8 +344,9 @@ VoiceTracker::VoiceTracker(const QString &logname,QString *import_path,
   track_play_button=new RDTransportButton(RDTransportButton::Play,this,
 					 "track_play_button");
   track_play_button->setGeometry(20,265,80,50);
-  track_play_button->
-    setPalette(QPalette(backgroundColor(),colorGroup().mid()));
+  track_play_button->setPalette(QPalette(QColor(system_button_color),QColor(system_mid_color)));
+//  track_play_button->
+//    setPalette(QPalette(backgroundColor(),colorGroup().mid()));
   connect(track_play_button,SIGNAL(clicked()),
 	  this,SLOT(playData()));
 
@@ -353,8 +356,9 @@ VoiceTracker::VoiceTracker(const QString &logname,QString *import_path,
   track_stop_button=new RDTransportButton(RDTransportButton::Stop,this,
 					 "track_stop_button");
   track_stop_button->setGeometry(110,265,80,50);
-  track_stop_button->
-    setPalette(QPalette(backgroundColor(),colorGroup().mid()));
+  track_stop_button->setPalette(QPalette(QColor(system_button_color),QColor(system_mid_color)));
+//  track_stop_button->
+//    setPalette(QPalette(backgroundColor(),colorGroup().mid()));
   track_stop_button->setOnColor(red);
   track_stop_button->on();
   connect(track_stop_button,SIGNAL(clicked()),this,SLOT(stopData()));
@@ -375,7 +379,7 @@ VoiceTracker::VoiceTracker(const QString &logname,QString *import_path,
   edit_length_label=new QLabel(this,"edit_length_label");
   edit_length_label->setText("-:--:--.-");
   edit_length_label->setGeometry(565,255,110,25);
-  edit_length_label->setBackgroundColor(white);
+//  edit_length_label->setBackgroundColor(white);
   edit_length_label->setAlignment(AlignCenter);
   edit_length_label->setFont(timer_font);
 
@@ -390,7 +394,7 @@ VoiceTracker::VoiceTracker(const QString &logname,QString *import_path,
   edit_tracks_remaining_label=new QLabel(this,"edit_tracks_remaining_label");
   edit_tracks_remaining_label->setText("0");
   edit_tracks_remaining_label->setGeometry(565,313,40,18);
-  edit_tracks_remaining_label->setBackgroundColor(white);
+//  edit_tracks_remaining_label->setBackgroundColor(white);
   edit_tracks_remaining_label->setAlignment(AlignCenter);
   edit_tracks_remaining_label->setFont(label_font);
   label=new QLabel(tr("Tracks"),this,"label");
@@ -402,7 +406,7 @@ VoiceTracker::VoiceTracker(const QString &logname,QString *import_path,
   edit_time_remaining_label=new QLabel(this,"edit_time_remaining_label");
   edit_time_remaining_label->setText("0:00:00.0");
   edit_time_remaining_label->setGeometry(615,313,60,18);
-  edit_time_remaining_label->setBackgroundColor(white);
+//  edit_time_remaining_label->setBackgroundColor(white);
   edit_time_remaining_label->setAlignment(AlignCenter);
   edit_time_remaining_label->setFont(label_font);
   edit_time_remaining_palette[0]=edit_time_remaining_label->palette();

--- a/rdlogmanager/edit_event.cpp
+++ b/rdlogmanager/edit_event.cpp
@@ -190,8 +190,8 @@ EditEvent::EditEvent(QString eventname,bool new_event,
 			 this,"event_player");
     event_player->playButton()->
       setGeometry(CENTER_LINE-180,sizeHint().height()-210,80,50);
-    event_player->stopButton()->
-      setPalette(QPalette(backgroundColor(),QColor(lightGray)));
+//    event_player->stopButton()->
+//      setPalette(QPalette(backgroundColor(),QColor(lightGray)));
     event_player->stopButton()->setGeometry(CENTER_LINE-90,sizeHint().height()-210,80,50);
     event_player->stopButton()->setOnColor(red);
   }


### PR DESCRIPTION
Rivendell has not worked with dark color themes from a factory install; RDAirplay has a fixed background on the log items but uses the system foreground color for text.

This patch modifies rivendell-2.10.1 to support dark themes, such as defaults with KXStudio. It also retains support for the original color theme that rivendell was developed for.

For example screen shots, please goto http://rivendell.danielbair.com/2014/11/30/rivendell-dark-theme-support/