### PR TITLE
Eliminate illegal SQL query when user has no groups

### DIFF
--- a/lib/rdcart_search_text.cpp
+++ b/lib/rdcart_search_text.cpp
@@ -162,7 +162,7 @@ QString RDAllCartSearchText(const QString &filter,const QString &schedcode,
 			      (const char *)q->value(0).toString());
   }
   delete q;
-  search=search.left(search.length()-2)+QString(")");
+  search+=QString("0)");
   search+=QString("&&")+RDBaseSearchText(filter,incl_cuts);
 
   if(!schedcode.isEmpty()) {


### PR DESCRIPTION
If you create a user and remove all their groups in rdadmin, then rdlogin to that user, then launch rdlibrary from the command line, you'll see a database error: mysql doesn't like the "()" in the WHERE clause. That empty ||-expression results from an empty subquery loop. This patch forces the ||-expression to always have at least 1 term.
