### PR TITLE
fix call to daemon()

### DIFF
--- a/lib/rdconf.cpp
+++ b/lib/rdconf.cpp
@@ -442,7 +442,7 @@ bool RDDetach(const QString &coredir)
   if(!coredir.isEmpty()) {
     chdir(coredir);
   }
-  if(daemon(coredir.isEmpty(),0)) {
+  if(daemon(!coredir.isEmpty(),0)) {
     return false;
   }
   return true;


### PR DESCRIPTION
The first argument to daemon was used wrongly. This lead to the
situation where core dumps where not created in the correct
directory ore not at all due to permission issues.

Signed-off-by: Christian Pointner <equinox@helsinki.at>