### PR TITLE
fix compiler warnings about unhandled M4A enum value

### DIFF
--- a/lib/rdwavefile.cpp
+++ b/lib/rdwavefile.cpp
@@ -1260,6 +1260,7 @@ void RDWaveFile::getSettings(RDSettings *settings)
 {
   switch(type()) {
   case RDWaveFile::Pcm8:
+  case RDWaveFile::M4A:
   case RDWaveFile::Aiff:
     // FIXME
     break;


### PR DESCRIPTION
This silences compiler warnings like:
 ...enumeration value 'M4A' not handled in switch...
which were introduced by recent MP4 decode support.

However the function getSettings of RDWaveFile is never called
which makes this a cosmetic change.

Signed-off-by: Christian Pointner <equinox@helsinki.at>