### PR TITLE
Voicetracker Speed Enhancement, Cut Scheduler Enhancement, Missing File Fix

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -15223,3 +15223,13 @@
 	and 'lib/rdedit_audio.h'.
 2016-02-21 Fred Gleason <fredg@paravelsystems.com>
 	* Optimized waveform updates in 'lib/rdmarkerwaveform.cpp'.
+2016-02-28 Brian McGlynn <brian.mcglynn@geneseemedia.net>
+        * Added modification market to Voicetracker to eliminate need to 
+        rewrite playlist upon minor changes
+        * Added modified flag in 'lib/rdlog_line.cpp' and 'lib/rdlog_line.h'
+        * Implemented saveModifid in 'lib/rdlog_event.cpp' and 'lib/rdlog_event.h'
+        * Added saveModified() function in 'rdlogedit/voice_tracker.cpp'
+2016-03-18 Brian McGlynn <brian.mcglynn@geneseemedia.net>
+        * Updated lib/rdcart.cpp, lib/rdcart.h, rdlibrary/rdlibrary.cpp, 
+        rdlibrary/list_report.cpp, rdlibrary/edit_cart.cpp, rdlibrary/edit_cart.h
+        * Added Random, Sequential, Least Played, and Expiring First cut scheduling

--- a/ChangeLog
+++ b/ChangeLog
@@ -15236,3 +15236,6 @@
 2016-03-19 Brian McGlynn <brian.mcglynn@geneseemedia.net>
         * Fixed playback issue in lib/rdcae.cpp.  If file was missing on
 	filesystem, rdairplay would get stopped on that track. 
+2016-03-25 Brian McGlynn <brian.mcglynn@geneseemedia.net>
+        * Fixed search issue in rdlibrary/rdlibrary.cpp. With "Limit to top 100 results"
+        was selected, not all 100 results were shown.

--- a/ChangeLog
+++ b/ChangeLog
@@ -15233,3 +15233,6 @@
         * Updated lib/rdcart.cpp, lib/rdcart.h, rdlibrary/rdlibrary.cpp, 
         rdlibrary/list_report.cpp, rdlibrary/edit_cart.cpp, rdlibrary/edit_cart.h
         * Added Random, Sequential, Least Played, and Expiring First cut scheduling
+2016-03-19 Brian McGlynn <brian.mcglynn@geneseemedia.net>
+        * Fixed playback issue in lib/rdcae.cpp.  If file was missing on
+	filesystem, rdairplay would get stopped on that track. 

--- a/docs/CutScheduler.txt
+++ b/docs/CutScheduler.txt
@@ -1,0 +1,21 @@
+Cuts are scheduled for playout at play-time based on the following logic:
+
+1. Least Played
+Cuts will be selected based on which one was played the least. This will provide
+balanced playout. Weighting is ignored.
+
+
+2. Randomly
+Cuts will be selected based on randomizing their playback. Playout is influenced
+by weighting and by how frequently (infrequently) a cut has been played.
+
+
+3. Expiring First
+Cuts that expire first and are played the least will be put first. This ensures that 
+those cuts will be prioritized to play before they expire. Weighting is ignored.
+
+
+4. Sequentially
+Cuts in a cart will be played in their order (1, 2, 3, etc..) sequentially. 
+This is useful with sports game sponsors.  There is no attention paid to 
+play count or weighting. 

--- a/lib/rdcae.cpp
+++ b/lib/rdcae.cpp
@@ -147,6 +147,7 @@ bool RDCae::loadPlay(int card,QString name,int *stream,int *handle)
   if(count>1000) {
     syslog(LOG_ERR,"*** LoadPlay: CAE took %d mS to return stream for %s ***",
 	   count,(const char *)name);
+    return false;
   }
   cae_handle[card][*stream]=*handle;
   cae_pos[card][*stream]=0xFFFFFFFF;
@@ -158,7 +159,6 @@ bool RDCae::loadPlay(int card,QString name,int *stream,int *handle)
   }
  
   return true;
-
 
 }
 

--- a/lib/rdcae.cpp
+++ b/lib/rdcae.cpp
@@ -136,18 +136,30 @@ bool RDCae::loadPlay(int card,QString name,int *stream,int *handle)
   //
   *stream=-2;
   *handle=-1;
+
+  // Wait for CAE Daemon to return status for loading this stream
   while(*stream==-2) {
     readyData(stream,handle,name);
     usleep(1000);
     count++;
   }
+  // Timeout for receiving confirmation
   if(count>1000) {
     syslog(LOG_ERR,"*** LoadPlay: CAE took %d mS to return stream for %s ***",
 	   count,(const char *)name);
   }
   cae_handle[card][*stream]=*handle;
   cae_pos[card][*stream]=0xFFFFFFFF;
+
+  // CAE Daemon sends back a stream of -1 if there is an issue with allocating it
+  // such as file missing, etc.
+  if(*stream < 0) {
+     return false;
+  }
+ 
   return true;
+
+
 }
 
 

--- a/lib/rdcart.cpp
+++ b/lib/rdcart.cpp
@@ -28,9 +28,11 @@
 #endif  // WIN32
 
 #include <vector>
+#include <algorithm>
 
 #include <qstringlist.h>
 #include <qobject.h>
+#include <qdatetime.h>
 
 #include <rd.h>
 #include <rdconf.h>
@@ -83,7 +85,6 @@ bool RDCart::selectCut(QString *cut) const
   return selectCut(cut,QTime::currentTime());
 }
 
-
 bool RDCart::selectCut(QString *cut,const QTime &time) const
 {
   bool ret;
@@ -92,9 +93,9 @@ bool RDCart::selectCut(QString *cut,const QTime &time) const
     ret=(*cut=="");
     *cut="";
 #ifndef WIN32
-    syslog(LOG_USER|LOG_WARNING,
-	   "RDCart::selectCut(): cart doesn't exist, CUT=%s",
-	   (const char *)cut);
+    //syslog(LOG_USER|LOG_WARNING,
+    //	   "RDCart::selectCut(): cart doesn't exist, CUT=%s",
+    //	   (const char *)cut);
 #endif  // WIN32
     return ret;
   }
@@ -111,50 +112,79 @@ bool RDCart::selectCut(QString *cut,const QTime &time) const
   QString datetime_str=QDateTime(current_date,time).
     toString("yyyy-MM-dd hh:mm:ss");
   QString time_str=QDateTime(current_date,time).toString("hh:mm:ss");
+  QString orderBy = "";
 
-  //  if(type()==RDCart::Audio) {
+  // enum PlayOrder {LeastPlayed=0,Random=1,ExpFirst=2,Sequence=3};
+  // case RDCart::Random: {
   switch(type()) {
-  case RDCart::Audio:
-    sql=QString().sprintf("select CUT_NAME,WEIGHT,LOCAL_COUNTER\
+  case RDCart::Audio: {
+
+    // Order the result set based on schedule type
+    switch(playOrder()) {
+    case RDCart::Random:
+       //Next function expects last one played to be first record
+       orderBy = "order by LAST_PLAY_DATETIME DESC";
+    case RDCart::ExpFirst:
+       orderBy = "order by PLAY_COUNTER ASC, ISNULL(END_DATETIME), END_DATETIME ASC \
+                  LAST_PLAY_DATETIME ASC";
+    case RDCart::LeastPlayed:
+       orderBy = "order by PLAY_COUNTER ASC, LAST_PLAY_DATETIME ASC, \
+                  ISNULL(END_DATETIME), END_DATETIME ASC";
+    case RDCart::Sequence:
+       orderBy = "order by CUT_NAME ASC";
+    }
+    sql=QString().sprintf("select CUT_NAME,WEIGHT,LOCAL_COUNTER,PLAY_COUNTER,\
+                           LAST_PLAY_DATETIME \
                            from CUTS  where (((START_DATETIME<=\"%s\")&&\
                            (END_DATETIME>=\"%s\"))||\
                            (START_DATETIME is null))&&\
                            (((START_DAYPART<=\"%s\")&&(END_DAYPART>=\"%s\")||\
                            START_DAYPART is null))&&\
-                           (%s=\"Y\")&&(CART_NUMBER=%u)&&(EVERGREEN=\"N\")&&\
-                           (LENGTH>0) order by LOCAL_COUNTER",
+                           (%s=\"Y\")&&(CART_NUMBER=%u)&&(EVERGREEN=\"N\")&& (LENGTH>0) %s",
 			  (const char *)datetime_str,
 			  (const char *)datetime_str,
 			  (const char *)time_str,
 			  (const char *)time_str,
-	(const char *)RDGetShortDayNameEN(current_date.dayOfWeek()).upper(),
-			  cart_number);
+                          (const char *)RDGetShortDayNameEN(current_date.dayOfWeek()).upper(),
+			  cart_number, 
+                          (const char *)orderBy);
     q=new RDSqlQuery(sql);
-    cutname=GetNextCut(q);
-    delete q;
-    break;
+#ifndef WIN32
+    //syslog(LOG_USER|LOG_WARNING,"RDCart::selectCut(): SQL=%s",(const char *)sql);
+#endif
+    
+    // Is there a result in range, use it
+    if(q->size() > 0 ) {
+       cutname=GetNextCut(q);
+       delete q;
+       break;
+    }
+    // if not, try to get the evergreen cut
+    else {
+       sql=QString().sprintf("select CUT_NAME,WEIGHT,LOCAL_COUNTER,PLAY_COUNTER\
+                           from CUTS where (CART_NUMBER=%u)&&\
+                           (EVERGREEN=\"Y\")&&(LENGTH>0) \
+                           order by PLAY_COUNTER ASC, LAST_PLAY_DATETIME ASC",
+		 	   cart_number);
+       delete q;
+       q=new RDSqlQuery(sql);
+#ifndef WIN32
+       //syslog(LOG_USER|LOG_WARNING,"RDCart::selectCut(): no valid cuts, trying evergreen, SQL=%s",(const char *)sql);
+#endif 
+       cutname=GetNextCut(q);
+       delete q;
 
+       if(cutname.isEmpty()) {
+#ifndef WIN32
+          //syslog(LOG_USER|LOG_WARNING,"RDCart::selectCut(): no valid regular or evergreen cuts, SQL=%s",(const char *)sql);
+#endif  
+       }
+       break;
+     }
+  }
   case RDCart::Macro:
   case RDCart::All:
     break;
-  }
-  if(cutname.isEmpty()) {   // No valid cuts, try the evergreen
-#ifndef WIN32
-    // syslog(LOG_USER|LOG_WARNING,"RDCart::selectCut(): no valid cuts, trying evergreen, SQL=%s",(const char *)sql);
-#endif  // WIN32
-    sql=QString().sprintf("select CUT_NAME,WEIGHT,LOCAL_COUNTER\
-                           from CUTS where (CART_NUMBER=%u)&&\
-                           (EVERGREEN=\"Y\")&&(LENGTH>0) \
-                           order by LOCAL_COUNTER",
-			  cart_number);
-    q=new RDSqlQuery(sql);
-    cutname=GetNextCut(q);
-    delete q;
-  }
-  if(cutname.isEmpty()) {
-#ifndef WIN32
-    // syslog(LOG_USER|LOG_WARNING,"RDCart::selectCut(): no valid evergreen cuts, SQL=%s",(const char *)sql);
-#endif  // WIN32
   }
   *cut=cutname;
   return true;
@@ -1324,7 +1354,6 @@ bool RDCart::exists(unsigned cartnum)
   return ret;
 }
 
-
 QString RDCart::playOrderText(RDCart::PlayOrder order)
 {
   switch(order) {
@@ -1333,6 +1362,12 @@ QString RDCart::playOrderText(RDCart::PlayOrder order)
 
       case RDCart::Random:
 	return QObject::tr("Randomly");
+
+      case RDCart::LeastPlayed:
+	return QObject::tr("Least Played");
+
+      case RDCart::ExpFirst:
+	return QObject::tr("Expiring First");
   }
   return QObject::tr("Unknown");
 }
@@ -1490,20 +1525,134 @@ void RDCart::removePending(RDStation *station,RDUser *user,RDConfig *config)
 }
 
 
+// This function selects the cuts from a SQL Query Structure
+// All eligible cuts are returned from the query sorted by what
+// Can be played, the number of times played, and weighted
 QString RDCart::GetNextCut(RDSqlQuery *q) const
 {
+
   QString cutname;
-  double ratio;
-  double play_ratio=100000000.0;
-  std::vector<int> eligibles;
+  std::vector<QString> eligibles;
+  int maxPlays = 0;
+  int minPlays = -1;
 
+  // Fields:
+  // 0 = Cut Number
+  // 1 = Weight
+  // 2 = Local Count
+  // 3 = Play Count
+  // 4 = Last Play (DateTime)
+ 
+#ifdef WIN32
+  q->next();
+  cutname=q->value(0).toString();
+#else
 
-  while(q->next()) {
-    if((ratio=q->value(2).toDouble()/q->value(1).toDouble())<play_ratio) {
-      play_ratio=ratio;
-      cutname=q->value(0).toString();
-    }
+  // Zero Result Set Test -- This happens in the course of "normal" operation.
+  // This is common with future tracks in the playlist
+  if(q->size() <= 0) {
+    //syslog(LOG_USER|LOG_WARNING,"Zero query results sent to GetNextCut. Returning zero.");
+    cutname = "";
+    return cutname;
   }
+
+  switch(playOrder()) {
+      case RDCart::Random: {
+
+        
+        // Step 1 -- Spin through results to get highest and lowest counts
+        while(q->next()) {
+          if(q->value(3).toInt() > maxPlays ) {
+             maxPlays = q->value(3).toInt();
+          }
+          if(q->value(3).toInt() < minPlays) {
+             minPlays = q->value(3).toInt();
+          }
+          else if (minPlays == -1) {
+             // Sets the marker for the first time
+             minPlays = maxPlays;
+          }
+          else { }
+        }
+        int playRange = maxPlays - minPlays;
+  
+        // To avoid playing the same item back to back, exclude the first record 
+        // (which is sorted by most recent play) if there is more than one result
+        if(q->size() < 2) {
+           q->seek(-1); // Back-Up candidate list query to beginning
+        }
+        else {
+           q->seek(0); // Skip first record
+        }
+
+        // Step 2 -- Load up a new vector weighted on plays and weight
+        while(q->next()) {
+
+          //TODO - Only push if this is not the last played and 2 or more records
+          int plays = q->value(3).toInt() - minPlays; //Set plays relative range
+          int weight = q->value(1).toInt();
+          int adds = weight * (playRange + 1 - plays);
+
+          for(int i=0 ; i < adds ; i++ ) {  
+               eligibles.push_back((QString)q->value(0).toString());
+          }
+
+        }
+        //Pick a random location in the vector
+        int totc = (int)eligibles.size();
+        int loct = rand() % totc;
+        cutname=(QString)eligibles[loct];
+  
+        break;
+        } 
+      case RDCart::Sequence: {
+
+        // Cuts come in sorted by name
+        // Step 2 -- Get Index of last played, add one.  
+        //          If none -- go to beginning
+        //          If at last, to to beginning
+
+        QString lastDate="";
+        int idxCtr = 0;
+        int lastCTR = 0;
+       
+        //Wind through results and find earliest non-null) date 
+        while(q->next()) {
+
+           QString playDate=(QString)q->value(4).toString();
+          
+           //If Current playDate is less than lowDate_Saved, set lowDate
+           if((playDate > lastDate) && (playDate != NULL)) {
+              lastDate = playDate;
+              lastCTR = idxCtr;
+           }
+
+           idxCtr++;
+        }
+        //Pick the next cut based on the index, or wrap to zero
+        lastCTR++;
+        if(lastCTR >= ((int)q->size())) {
+           //If idxCTR is size of Query set, then reset to zero
+           q->seek(0,false);
+           cutname=q->value(0).toString();
+        }
+        else {
+           //Add one to index
+           q->seek(lastCTR,false);
+           cutname=q->value(0).toString();
+        }
+
+        break;
+      }
+      default:
+        // Default is  RDCart::LeastPlayed and RDCart::ExpFirst
+        // Take the first (least played) in the list. 
+        q->next();
+        cutname=q->value(0).toString();
+        break;
+  }
+
+#endif  // WIN32
   return cutname;
 }
 
@@ -1699,3 +1848,4 @@ void RDCart::SetRow(const QString &param) const
   q=new RDSqlQuery(sql);
   delete q;
 }
+

--- a/lib/rdcart.cpp
+++ b/lib/rdcart.cpp
@@ -124,14 +124,18 @@ bool RDCart::selectCut(QString *cut,const QTime &time) const
     case RDCart::Random:
        //Next function expects last one played to be first record
        orderBy = "order by LAST_PLAY_DATETIME DESC";
+       break;
     case RDCart::ExpFirst:
-       orderBy = "order by PLAY_COUNTER ASC, ISNULL(END_DATETIME), END_DATETIME ASC \
+       orderBy = "order by PLAY_COUNTER ASC, ISNULL(END_DATETIME), END_DATETIME ASC, \
                   LAST_PLAY_DATETIME ASC";
+       break;
     case RDCart::LeastPlayed:
        orderBy = "order by PLAY_COUNTER ASC, LAST_PLAY_DATETIME ASC, \
                   ISNULL(END_DATETIME), END_DATETIME ASC";
+       break;
     case RDCart::Sequence:
        orderBy = "order by CUT_NAME ASC";
+       break;
     }
     sql=QString().sprintf("select CUT_NAME,WEIGHT,LOCAL_COUNTER,PLAY_COUNTER,\
                            LAST_PLAY_DATETIME \

--- a/lib/rdcart.h
+++ b/lib/rdcart.h
@@ -40,7 +40,7 @@ class RDCart
 {
  public:
   enum Type {All=0,Audio=1,Macro=2};
-  enum PlayOrder {Sequence=0,Random=1};
+  enum PlayOrder {LeastPlayed=0,Random=1,ExpFirst=2,Sequence=3};
   enum UsageCode {UsageFeature=0,UsageOpen=1,UsageClose=2,UsageTheme=3,
 		  UsageBackground=4,UsagePromo=5,UsageLast=6};
   enum Validity {NeverValid=0,ConditionallyValid=1,AlwaysValid=2,

--- a/lib/rdlog_event.cpp
+++ b/lib/rdlog_event.cpp
@@ -133,6 +133,14 @@ int RDLogEvent::load(bool track_ptrs)
   return log_line.size();
 }
 
+void RDLogEvent::saveModified(bool update_tracks)
+{
+  for(unsigned i=0;i<log_line.size();i++) {
+    if(log_line[i]->hasBeenModified()) {
+      save(update_tracks, i);
+    }
+  }
+}
 
 void RDLogEvent::save(bool update_tracks,int line)
 {
@@ -159,6 +167,8 @@ void RDLogEvent::save(bool update_tracks,int line)
     q=new RDSqlQuery(sql);
     delete q;
     SaveLine(line);
+    // BPM - Clear the modified flag
+    log_line[line]->clearModified();
   }
   RDLog *log=new RDLog(log_name.left(log_name.length()-4));
   if(log->nextId()<nextId()) {
@@ -1098,6 +1108,7 @@ from `%s` left join CART on `%s`.CART_NUMBER=CART.NUMBER order by COUNT",
 	   q->value(40).toInt());
 */
 
+    line.clearModified();
     log_line.push_back(new RDLogLine(line));
   }
   delete q;

--- a/lib/rdlog_event.cpp
+++ b/lib/rdlog_event.cpp
@@ -157,8 +157,15 @@ void RDLogEvent::save(bool update_tracks,int line)
       delete q;
     }
     RDCreateLogTable(log_name);
-    for(unsigned i=0;i<log_line.size();i++) {
-      SaveLine(i);
+    if (log_line.size() > 0) {
+       QString values = "";
+       for(unsigned i=0;i<log_line.size();i++) {
+         InsertLineValues(&values, i);
+        if (i<log_line.size()-1) {
+           values += ",";
+         }
+       }
+       InsertLines(values);
     }
   }
   else {
@@ -1156,79 +1163,86 @@ from `%s` left join CART on `%s`.CART_NUMBER=CART.NUMBER order by COUNT",
 }
 
 
-void RDLogEvent::SaveLine(int line)
-{
+
+void RDLogEvent::InsertLines(QString values) {
   QString sql;
   RDSqlQuery *q;
-  sql=QString().sprintf("insert into `%s` set ID=%d,COUNT=%d,\
-                         CART_NUMBER=%u,START_TIME=%d,TIME_TYPE=%d,\
-                         TRANS_TYPE=%d,START_POINT=%d,END_POINT=%d,\
-                         SEGUE_START_POINT=%d,SEGUE_END_POINT=%d,TYPE=%d,\
-                         COMMENT=\"%s\",LABEL=\"%s\",GRACE_TIME=%d,\
-                         SOURCE=%d,EXT_START_TIME=\"%s\",\
-                         EXT_LENGTH=%d,EXT_DATA=\"%s\",EXT_EVENT_ID=\"%s\",\
-                         EXT_ANNC_TYPE=\"%s\",EXT_CART_NAME=\"%s\",\
-                         FADEUP_POINT=%d,FADEUP_GAIN=%d,FADEDOWN_POINT=%d,\
-                         FADEDOWN_GAIN=%d,SEGUE_GAIN=%d,\
-                         LINK_EVENT_NAME=\"%s\",LINK_START_TIME=%d,\
-                         LINK_LENGTH=%d,LINK_ID=%d,LINK_EMBEDDED=\"%s\",\
-                         ORIGIN_USER=\"%s\",ORIGIN_DATETIME=\"%s\",\
-                         LINK_START_SLOP=%d,LINK_END_SLOP=%d,\
-                         DUCK_UP_GAIN=%d,DUCK_DOWN_GAIN=%d,\
-                         EVENT_LENGTH=%d",
-			(const char *)log_name,
-			log_line[line]->id(),
-			line,
-			log_line[line]->cartNumber(),
-			QTime().msecsTo(log_line[line]->
-					startTime(RDLogLine::Logged)),
-			(int)log_line[line]->timeType(),
-			(int)log_line[line]->transType(),
-			log_line[line]->startPoint(RDLogLine::LogPointer),
-			log_line[line]->endPoint(RDLogLine::LogPointer),
-			log_line[line]->segueStartPoint(RDLogLine::LogPointer),
-			log_line[line]->segueEndPoint(RDLogLine::LogPointer),
-			log_line[line]->type(),
-			(const char *)
-			RDEscapeString(log_line[line]->markerComment()),
-			(const char *)
-			RDEscapeString(log_line[line]->markerLabel()),
-			log_line[line]->graceTime(),
-			log_line[line]->source(),
-			(const char *)log_line[line]->extStartTime().
-			toString("hh:mm:ss"),
-			log_line[line]->extLength(),
-			(const char *)RDEscapeString(log_line[line]->extData()),
-			(const char *)
-			RDEscapeString(log_line[line]->extEventId()),
-			(const char *)
-			RDEscapeString(log_line[line]->extAnncType()),
-			(const char *)
-			RDEscapeString(log_line[line]->extCartName()),
-			log_line[line]->fadeupPoint(RDLogLine::LogPointer),
-			log_line[line]->fadeupGain(),
-			log_line[line]->fadedownPoint(RDLogLine::LogPointer),
-			log_line[line]->fadedownGain(),
-			log_line[line]->segueGain(),
-			(const char *)
-			RDEscapeString(log_line[line]->linkEventName()),
-			QTime().msecsTo(log_line[line]->linkStartTime()),
-			log_line[line]->linkLength(),
-			log_line[line]->linkId(),
-			(const char *)RDYesNo(log_line[line]->linkEmbedded()),
-			(const char *)
-			RDEscapeString(log_line[line]->originUser()),
-			(const char *)log_line[line]->originDateTime().
-			toString("yyyy-MM-dd hh:mm:ss"),
-			log_line[line]->linkStartSlop(),
-			log_line[line]->linkEndSlop(),
-                        log_line[line]->duckUpGain(),
-                        log_line[line]->duckDownGain(),
-			log_line[line]->eventLength());
 
-  // printf("SQL: %s\n",(const char *)sql);
+  sql = QString().sprintf("insert into `%s` (ID,COUNT,CART_NUMBER,START_TIME,TIME_TYPE,\
+  TRANS_TYPE,START_POINT,END_POINT,SEGUE_START_POINT,SEGUE_END_POINT,TYPE, \
+  COMMENT,LABEL,GRACE_TIME,SOURCE,EXT_START_TIME,                       \
+  EXT_LENGTH,EXT_DATA,EXT_EVENT_ID,EXT_ANNC_TYPE,EXT_CART_NAME,         \
+  FADEUP_POINT,FADEUP_GAIN,FADEDOWN_POINT,FADEDOWN_GAIN,SEGUE_GAIN,     \
+  LINK_EVENT_NAME,LINK_START_TIME,LINK_LENGTH,LINK_ID,LINK_EMBEDDED,    \
+  ORIGIN_USER,ORIGIN_DATETIME,LINK_START_SLOP,LINK_END_SLOP,            \
+  DUCK_UP_GAIN,DUCK_DOWN_GAIN,EVENT_LENGTH) values %s",
+                          (const char *)log_name,
+                          (const char *)values);
   q=new RDSqlQuery(sql);
   delete q;
+}
+
+
+void RDLogEvent::InsertLineValues(QString *query, int line)
+{
+  // one line to save query space
+  QString sql=QString().sprintf("(%d,%d,%u,%d,%d,%d,%d,%d,%d,%d,%d,\"%s\",\"%s\",%d,%d,\"%s\",%d,\"%s\",\"%s\",\"%s\",\"%s\",%d,%d,%d,%d,%d,\"%s\",%d,%d,%d,\"%s\",\"%s\",\"%s\",%d,%d,%d,%d,%d)",
+                        log_line[line]->id(),
+                        line,
+                        log_line[line]->cartNumber(),
+                        QTime().msecsTo(log_line[line]->
+                                        startTime(RDLogLine::Logged)),
+                        (int)log_line[line]->timeType(),
+                        (int)log_line[line]->transType(),
+                        log_line[line]->startPoint(RDLogLine::LogPointer),
+                        log_line[line]->endPoint(RDLogLine::LogPointer),
+                        log_line[line]->segueStartPoint(RDLogLine::LogPointer),
+                        log_line[line]->segueEndPoint(RDLogLine::LogPointer),
+                        log_line[line]->type(),
+                        (const char *)
+                        RDEscapeString(log_line[line]->markerComment()),
+                        (const char *)
+                        RDEscapeString(log_line[line]->markerLabel()),
+                        log_line[line]->graceTime(),
+                        log_line[line]->source(),
+                        (const char *)log_line[line]->extStartTime().
+                        toString("hh:mm:ss"),
+                        log_line[line]->extLength(),
+                        (const char *)RDEscapeString(log_line[line]->extData()),
+                        (const char *)
+                        RDEscapeString(log_line[line]->extEventId()),
+                        (const char *)
+                        RDEscapeString(log_line[line]->extAnncType()),
+                        (const char *)
+                        RDEscapeString(log_line[line]->extCartName()),
+                        log_line[line]->fadeupPoint(RDLogLine::LogPointer),
+                        log_line[line]->fadeupGain(),
+                        log_line[line]->fadedownPoint(RDLogLine::LogPointer),
+                        log_line[line]->fadedownGain(),
+                        log_line[line]->segueGain(),
+                        (const char *)
+                        RDEscapeString(log_line[line]->linkEventName()),
+                        QTime().msecsTo(log_line[line]->linkStartTime()),
+                        log_line[line]->linkLength(),
+                        log_line[line]->linkId(),
+                        (const char *)RDYesNo(log_line[line]->linkEmbedded()),
+                        (const char *)
+                        RDEscapeString(log_line[line]->originUser()),
+                        (const char *)log_line[line]->originDateTime().
+                        toString("yyyy-MM-dd hh:mm:ss"),
+                        log_line[line]->linkStartSlop(),
+                        log_line[line]->linkEndSlop(),
+                        log_line[line]->duckUpGain(),
+                        log_line[line]->duckDownGain(),
+                        log_line[line]->eventLength());
+  *query += sql;
+}
+
+void RDLogEvent::SaveLine(int line)
+{
+  QString values = "";
+  InsertLineValues(&values, line);
+  InsertLines(values);
 }
 
 

--- a/lib/rdlog_event.h
+++ b/lib/rdlog_event.h
@@ -45,6 +45,7 @@ class RDLogEvent
    void setLogName(QString logname);
    QString serviceName() const;
    int load(bool track_ptrs=false);
+   void saveModified(bool update_tracks=true);
    void save(bool update_tracks=true,int line=-1);
    int append(const QString &logname,bool track_ptrs=false);
    int validate(QString *report,const QDate &date);

--- a/lib/rdlog_event.h
+++ b/lib/rdlog_event.h
@@ -76,6 +76,8 @@ class RDLogEvent
   private:
    int LoadLines(const QString &log_table,int id_offset,bool track_ptrs);
    void SaveLine(int line);
+   void InsertLines(QString values);
+   void InsertLineValues(QString *query, int line);
    void LoadNowNext(unsigned from_line);
    QString log_name;
    QString log_service_name;

--- a/lib/rdlog_line.cpp
+++ b/lib/rdlog_line.cpp
@@ -67,9 +67,19 @@ RDLogLine::RDLogLine(unsigned cartnum)
   delete q;
 }
 
+void RDLogLine::clearModified(void)
+{
+  modified = false;
+}
+
+bool RDLogLine::hasBeenModified(void)
+{
+  return modified;
+}
 
 void RDLogLine::clear()
 {
+  clearModified();
   log_id=-1;
   log_status=RDLogLine::Scheduled;
   log_state=RDLogLine::Ok;
@@ -215,6 +225,7 @@ int RDLogLine::id() const
 void RDLogLine::setId(int id)
 {
   log_id=id;
+  modified=true;
 }
 
 
@@ -320,6 +331,7 @@ RDLogLine::Source RDLogLine::source() const
 void RDLogLine::setSource(RDLogLine::Source src)
 {
   log_source=src;
+  modified=true;
 }
 
 
@@ -332,6 +344,7 @@ unsigned RDLogLine::cartNumber() const
 void RDLogLine::setCartNumber(unsigned cart)
 {
   log_cart_number=cart;
+  modified=true;
 }
 
 
@@ -359,6 +372,7 @@ int RDLogLine::graceTime() const
 void RDLogLine::setGraceTime(int time)
 {
   log_grace_time=time;
+  modified=true;
 }
 
 
@@ -383,6 +397,7 @@ QString RDLogLine::originUser() const
 void RDLogLine::setOriginUser(const QString &username)
 {
   log_origin_user=username;
+  modified=true;
 }
 
 
@@ -395,6 +410,7 @@ QDateTime RDLogLine::originDateTime() const
 void RDLogLine::setOriginDateTime(const QDateTime &datetime)
 {
   log_origin_datetime=datetime;
+  modified=true;
 }
 
 
@@ -425,6 +441,7 @@ int RDLogLine::startPoint(PointerSource ptr) const
 void RDLogLine::setStartPoint(int point,PointerSource ptr)
 {
   log_start_point[ptr]=point;
+  modified=true;
 }
 
 
@@ -443,6 +460,7 @@ int RDLogLine::endPoint(PointerSource ptr) const
 void RDLogLine::setEndPoint(int point,PointerSource ptr)
 {
   log_end_point[ptr]=point;
+  modified=true;
 }
 
 
@@ -467,6 +485,7 @@ int RDLogLine::segueStartPoint(PointerSource ptr) const
 void RDLogLine::setSegueStartPoint(int point,PointerSource ptr)
 {
   log_segue_start_point[ptr]=point;
+  modified=true;
 }
 
 
@@ -491,6 +510,7 @@ int RDLogLine::segueEndPoint(PointerSource ptr) const
 void RDLogLine::setSegueEndPoint(int point,PointerSource ptr)
 {
   log_segue_end_point[ptr]=point;
+  modified=true;
 }
 
 
@@ -508,6 +528,7 @@ int RDLogLine::segueGain() const
 void RDLogLine::setSegueGain(int gain)
 {
   log_segue_gain=gain;
+  modified=true;
 }
 
 
@@ -532,6 +553,7 @@ int RDLogLine::fadeupPoint(RDLogLine::PointerSource ptr) const
 void RDLogLine::setFadeupPoint(int point,RDLogLine::PointerSource ptr)
 {
   log_fadeup_point[ptr]=point;
+  modified=true;
 }
 
 
@@ -544,6 +566,7 @@ int RDLogLine::fadeupGain() const
 void RDLogLine::setFadeupGain(int gain)
 {
   log_fadeup_gain=gain;
+  modified=true;
 }
 
 
@@ -568,6 +591,7 @@ int RDLogLine::fadedownPoint(RDLogLine::PointerSource ptr) const
 void RDLogLine::setFadedownPoint(int point,RDLogLine::PointerSource ptr)
 {
   log_fadedown_point[ptr]=point;
+  modified=true;
 }
 
 
@@ -580,6 +604,7 @@ int RDLogLine::fadedownGain() const
 void RDLogLine::setFadedownGain(int gain)
 {
   log_fadedown_gain=gain;
+  modified=true;
 }
 
 
@@ -592,6 +617,7 @@ int RDLogLine::duckUpGain() const
 void RDLogLine::setDuckUpGain(int gain)
 {
   log_duck_up_gain=gain;
+  modified=true;
 }
 
 int RDLogLine::duckDownGain() const
@@ -603,6 +629,7 @@ int RDLogLine::duckDownGain() const
 void RDLogLine::setDuckDownGain(int gain)
 {
   log_duck_down_gain=gain;
+  modified=true;
 }
 
 
@@ -675,6 +702,7 @@ RDCart::Type RDLogLine::cartType() const
 void RDLogLine::setCartType(RDCart::Type type)
 {
   log_cart_type=type;
+  modified=true;
 }
 
 
@@ -1071,6 +1099,7 @@ QString RDLogLine::markerComment() const
 void RDLogLine::setMarkerComment(const QString &str)
 {
   log_marker_comment=str;
+  modified=true;
 }
 
 
@@ -1083,6 +1112,7 @@ QString RDLogLine::markerLabel() const
 void RDLogLine::setMarkerLabel(const QString &str)
 {
   log_marker_label=str;
+  modified=true;
 }
 
 
@@ -1143,6 +1173,7 @@ QTime RDLogLine::extStartTime() const
 void RDLogLine::setExtStartTime(QTime time)
 {
   log_ext_start_time=time;
+  modified=true;
 }
 
 
@@ -1155,6 +1186,7 @@ int RDLogLine::extLength() const
 void RDLogLine::setExtLength(int length)
 {
   log_ext_length=length;
+  modified=true;
 }
 
 
@@ -1167,6 +1199,7 @@ QString RDLogLine::extCartName() const
 void RDLogLine::setExtCartName(const QString &name)
 {
   log_ext_cart_name=name;
+  modified=true;
 }
 
 
@@ -1179,6 +1212,7 @@ QString RDLogLine::extData() const
 void RDLogLine::setExtData(const QString &data)
 {
   log_ext_data=data;
+  modified=true;
 }
 
 
@@ -1191,6 +1225,7 @@ QString RDLogLine::extEventId() const
 void RDLogLine::setExtEventId(const QString &id)
 {
   log_ext_event_id=id;
+  modified=true;
 }
 
 
@@ -1203,6 +1238,7 @@ QString RDLogLine::extAnncType() const
 void RDLogLine::setExtAnncType(const QString &type)
 {
   log_ext_annc_type=type;
+  modified=true;
 }
 
 
@@ -1427,6 +1463,7 @@ QString RDLogLine::linkEventName() const
 void RDLogLine::setLinkEventName(const QString &name)
 {
   log_link_event_name=name;
+  modified=true;
 }
 
 
@@ -1439,6 +1476,7 @@ QTime RDLogLine::linkStartTime() const
 void RDLogLine::setLinkStartTime(const QTime &time)
 {
   log_link_start_time=time;
+  modified=true;
 }
 
 
@@ -1451,6 +1489,7 @@ int RDLogLine::linkLength() const
 void RDLogLine::setLinkLength(int msecs)
 {
   log_link_length=msecs;
+  modified=true;
 }
 
 
@@ -1463,6 +1502,7 @@ int RDLogLine::linkStartSlop() const
 void RDLogLine::setLinkStartSlop(int msecs)
 {
   log_link_start_slop=msecs;
+  modified=true;
 }
 
 
@@ -1487,6 +1527,7 @@ int RDLogLine::linkId() const
 void RDLogLine::setLinkId(int id)
 {
   log_link_id=id;
+  modified=true;
 }
 
 
@@ -1499,6 +1540,7 @@ bool RDLogLine::linkEmbedded() const
 void RDLogLine::setLinkEmbedded(bool state)
 {
   log_link_embedded=state;
+  modified=true;
 }
 
 

--- a/lib/rdlog_line.h
+++ b/lib/rdlog_line.h
@@ -32,6 +32,8 @@
 class RDLogLine
 {
  public:
+  bool hasBeenModified(void);
+
   enum StartTimeType {Imported=0,Logged=1,Predicted=2,Actual=3,Initial=4};
   enum TimeType {Relative=0,Hard=1,NoTime=255};
   enum TransType {Play=0,Segue=1,Stop=2,NoTrans=255};
@@ -52,6 +54,7 @@ class RDLogLine
   void clear();
   void clearExternalData();
   void clearTrackData(RDLogLine::TransEdge edge);
+  void clearModified(void);
   int id() const;
   void setId(int id);
   RDLogLine::Status status() const;
@@ -267,6 +270,7 @@ class RDLogLine
   void setHoldover(bool);
 
  private:
+  bool modified;
   int log_id;
   RDLogLine::Status log_status;
   RDLogLine::State log_state;

--- a/lib/rdwavefile.cpp
+++ b/lib/rdwavefile.cpp
@@ -210,6 +210,11 @@ bool RDWaveFile::openWave(RDWaveData *data)
   unsigned char tmc_buffer[4];
 
   wave_data=data;
+
+  // can try .exists() on the object
+  //if(!wave_file.exists()) {
+  //  return false;
+  //}
   if(!wave_file.open(IO_ReadOnly)) {
     return false;
   }

--- a/rdairplay/log_play.cpp
+++ b/rdairplay/log_play.cpp
@@ -335,6 +335,7 @@ bool LogPlay::play(int line,RDLogLine::StartSource src,
   }
   //
   // Play it
+  // TODO -- BPM: This is where the hook will likely go in for Serial playback
   //
   if(!GetNextPlayable(&line,skip_meta,true)) {
     return false;

--- a/rdlibrary/edit_cart.h
+++ b/rdlibrary/edit_cart.h
@@ -77,6 +77,7 @@ class EditCart : public QDialog
   QLineEdit *rdcart_type_edit;
   QLineEdit *rdcart_number_edit;
   QComboBox *rdcart_group_box;
+  QComboBox *rdcart_cut_sched_box;
   QLineEdit *rdcart_group_edit;
   AudioControls rdcart_controls;
   QCheckBox *rdcart_syncronous_box;
@@ -87,6 +88,7 @@ class EditCart : public QDialog
   QLineEdit *rdcart_average_length_edit;
   QLabel *rdcart_forced_length_label;
   QLineEdit *rdcart_forced_length_ledit;
+  QLineEdit *rdcart_cut_sched_edit;
   QCheckBox *rdcart_preserve_pitch_button;
   QLabel *rdcart_preserve_pitch_label;
   unsigned rdcart_average_length;

--- a/rdlibrary/list_reports.cpp
+++ b/rdlibrary/list_reports.cpp
@@ -279,8 +279,16 @@ void ListReports::GenerateCartReport(QString *report)
 	  *report+="SEQ ";
 	  break;
 
+	case RDCart::LeastPlayed:
+	  *report+="LSP ";
+	  break;
+
 	case RDCart::Random:
 	  *report+="RND ";
+	  break;
+
+	case RDCart::ExpFirst:
+	  *report+="EXF ";
 	  break;
 
 	default:

--- a/rdlibrary/rdlibrary.cpp
+++ b/rdlibrary/rdlibrary.cpp
@@ -1061,6 +1061,8 @@ void MainWidget::RefreshList()
   // 35 - CUTS.SAT
   // 36 - CUTS.SUN
   //
+  // ?? - CART.PLAY_ORDER
+  //
 
   sql="select CART.NUMBER,CART.FORCED_LENGTH,CART.TITLE,CART.ARTIST,\
        CART.ALBUM,CART.LABEL,\

--- a/rdlibrary/rdlibrary.cpp
+++ b/rdlibrary/rdlibrary.cpp
@@ -1092,7 +1092,7 @@ void MainWidget::RefreshList()
       RDCartSearchText(lib_filter_edit->text(),lib_group_box->currentText(),
 		       schedcode,true)+" && "+type_filter;      
   }
-  sql+=" order by CART.NUMBER";
+  sql+=" group by CART.NUMBER order by CART.NUMBER";
   if(lib_showmatches_box->isChecked()) {
     sql+=QString().sprintf(" limit %d",RD_LIMITED_CART_SEARCH_QUANTITY);
   }

--- a/rdlogedit/voice_tracker.cpp
+++ b/rdlogedit/voice_tracker.cpp
@@ -2331,7 +2331,12 @@ void VoiceTracker::SaveTrack(int line)
   if((line>0)&&(track_log_event->logLine(line-1)->type()==RDLogLine::Track)) {
     line--;
   }
-  track_log_event->save();
+  if(track_size_altered) {
+       track_log_event->save();
+  }
+  else {
+        track_log_event->saveModified();
+  }
   track_log->
     setModifiedDatetime(QDateTime(QDate::currentDate(),QTime::currentTime()));
   track_changed=false;


### PR DESCRIPTION
- Added modification market to Voicetracker to eliminate need to rewrite playlist upon minor changes.  Speeds up voicetracking inserts, and voicetracking over a WAN.
- Added modified flag in 'lib/rdlog_line.cpp' and 'lib/rdlog_line.h'
- Implemented saveModified() in 'lib/rdlog_event.cpp' and 'lib/rdlog_event.h'
- Added saveModified() function in 'rdlogedit/voice_tracker.cpp'

  * Updated lib/rdcart.cpp, lib/rdcart.h, rdlibrary/rdlibrary.cpp,  rdlibrary/list_report.cpp, rdlibrary/edit_cart.cpp, rdlibrary/edit_cart.h
   * Added Random, Sequential, Least Played, and Expiring First cut scheduling



