### PR TITLE
Fix for displaying full 100 carts and for missing files in /var/snd

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -15070,6 +15070,9 @@
 2016-04-14 Fred Gleason <fredg@paravelsystems.com>
 	* Removed the libXmu from the list of tested libraries for Qt3 in
 	'acinclude.m4'.
-2016-04-09 Brian McGlynn <brian.mcglynn@geneseemedia.net>
+2016-04-21 Brian McGlynn <brian.mcglynn@geneseemedia.net>
         * Updated lib/rdcae.cpp to return error code when file does not exist
 	in /var/snd
+2015-04-21 Brian McGlynn <brian.mcglynn@geneseemedia.net>
+        * Added "Group By" statement in rdlibrary/rdlibrary.cpp to allow a
+  	full 100 results to be shown

--- a/ChangeLog
+++ b/ChangeLog
@@ -15070,3 +15070,6 @@
 2016-04-14 Fred Gleason <fredg@paravelsystems.com>
 	* Removed the libXmu from the list of tested libraries for Qt3 in
 	'acinclude.m4'.
+2016-04-09 Brian McGlynn <brian.mcglynn@geneseemedia.net>
+        * Updated lib/rdcae.cpp to return error code when file does not exist
+	in /var/snd

--- a/lib/rdcae.cpp
+++ b/lib/rdcae.cpp
@@ -147,6 +147,13 @@ bool RDCae::loadPlay(int card,QString name,int *stream,int *handle)
   }
   cae_handle[card][*stream]=*handle;
   cae_pos[card][*stream]=0xFFFFFFFF;
+
+  // CAE Daemon sends back a stream of -1 if there is an issue with allocating it
+  // such as file missing, etc.
+  if(*stream < 0) {
+      return false;
+  }
+
   return true;
 }
 

--- a/rdlibrary/rdlibrary.cpp
+++ b/rdlibrary/rdlibrary.cpp
@@ -1090,7 +1090,7 @@ void MainWidget::RefreshList()
       RDCartSearchText(lib_filter_edit->text(),lib_group_box->currentText(),
 		       schedcode,true)+" && "+type_filter;      
   }
-  sql+=" order by CART.NUMBER";
+  sql+=" group by CART.NUMBER order by CART.NUMBER";
   if(lib_showmatches_box->isChecked()) {
     sql+=QString().sprintf(" limit %d",RD_LIMITED_CART_SEARCH_QUANTITY);
   }


### PR DESCRIPTION
This fixes a bug in RDLibrary when searching and there are multiple instances of a string within the cuts of a cart causing less than the full 100 carts to be returned.

For example, if you had 100 cuts called "PSA" in a PSA rotator cart, you would see only one entry for PSA upon doing a search. With this change, you can now see all 100 Carts.

If a file is missing in /var/snd, RDAirplay will hang and cause dead air. The CAE daemon will provide a status of -1 for the stream if the file is missing, This code implements a return of "false" if a -1 is received.