### PR TITLE
Fix to rdlibrary.cpp to show all 100 carts in search when there are multiple matches in cuts

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -15070,3 +15070,6 @@
 2016-04-14 Fred Gleason <fredg@paravelsystems.com>
 	* Removed the libXmu from the list of tested libraries for Qt3 in
 	'acinclude.m4'.
+2015-04-21 Brian McGlynn <brian.mcglynn@geneseemedia.net>
+        * Added "Group By" statement in rdlibrary/rdlibrary.cpp to allow a
+ 	full 100 results to be shown

--- a/rdlibrary/rdlibrary.cpp
+++ b/rdlibrary/rdlibrary.cpp
@@ -1090,7 +1090,7 @@ void MainWidget::RefreshList()
       RDCartSearchText(lib_filter_edit->text(),lib_group_box->currentText(),
 		       schedcode,true)+" && "+type_filter;      
   }
-  sql+=" order by CART.NUMBER";
+  sql+=" group by CART.NUMBER order by CART.NUMBER";
   if(lib_showmatches_box->isChecked()) {
     sql+=QString().sprintf(" limit %d",RD_LIMITED_CART_SEARCH_QUANTITY);
   }


### PR DESCRIPTION
When searching in RDLibrary and selecting for 100 results of less, sometimes not all results are shown. This occurs when there are cuts or other items that may match the search term.  

A GROUP BY statement was added to the SQL to solve this issue.