### PR TITLE
Fix for missing files in /var/snd causing RDairplay to hang

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -15070,3 +15070,6 @@
 2016-04-14 Fred Gleason <fredg@paravelsystems.com>
 	* Removed the libXmu from the list of tested libraries for Qt3 in
 	'acinclude.m4'.
+2016-04-09 Brian McGlynn <brian.mcglynn@geneseemedia.net>
+        * Updated lib/rdcae.cpp to return error code when file does not exist
+	in /var/snd

--- a/lib/rdcae.cpp
+++ b/lib/rdcae.cpp
@@ -147,6 +147,13 @@ bool RDCae::loadPlay(int card,QString name,int *stream,int *handle)
   }
   cae_handle[card][*stream]=*handle;
   cae_pos[card][*stream]=0xFFFFFFFF;
+
+  // CAE Daemon sends back a stream of -1 if there is an issue with allocating it
+  // such as file missing, etc.
+  if(*stream < 0) {
+      return false;
+  }
+
   return true;
 }
 


### PR DESCRIPTION
If a file is missing in the /var/snd directory, the CAE daemon will send a "-1" value for stream. The lib/rdcae.cpp file does not check for that status and always returns true.  This causes RDAirplay to hang indefinitely when trying to play a track.

This patch checks for this status indicator and returns a false allowing RDAirplay to skip over the file and not have dead air.