### PR TITLE
Favor soon-to-be-expiring cuts in weighted playback

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -15075,3 +15075,6 @@
 2016-04-23 Fred Gleason <fredg@paravelsystems.com>
 	* Renamed the 'ClockAddress' parameter to 'HostAddress' in
 	'rlm/rlm_walltime.c'.
+2016-04-23 Brian McGlynn <brian.mcglynn@geneseemedia.net>
+	* Updated Cart Scheduler to favor weighted playback for cuts expiring
+	first following the number of plays

--- a/lib/rdcart.cpp
+++ b/lib/rdcart.cpp
@@ -129,7 +129,8 @@ bool RDCart::selectCut(QString *cut,const QTime &time) const
       QString().sprintf("(CART_NUMBER=%u)&&(EVERGREEN=\"N\")&&",cart_number)+
       "(LENGTH>0)";
     if(useWeighting()) {
-      sql+=" order by LOCAL_COUNTER";
+      sql+=" order by LOCAL_COUNTER ASC, ISNULL(END_DATETIME), END_DATETIME ASC, \
+             LAST_PLAY_DATETIME ASC";
     }
     else {
       sql+=" order by LAST_PLAY_DATETIME desc";


### PR DESCRIPTION
Favors cuts expiring first in weighted playback. This is useful when announcements are placed in a cart that have a near-term expiration date.  