### PR TITLE
Fix compilation with gcc 6.1.1

### DIFF
--- a/lib/rdcartslot.cpp
+++ b/lib/rdcartslot.cpp
@@ -625,9 +625,10 @@ unsigned RDCartSlot::SelectCart(const QString &svcname,unsigned msecs)
     "(SERVICE=\""+RDEscapeString(svcname)+"\")";
   q=new RDSqlQuery(sql);
   while(q->next()) {
-    if(::abs(msecs-q->value(1).toInt())<diff) {
+    int cur_diff = msecs-q->value(1).toInt();
+    if(::abs(cur_diff)<diff) {
       cartnum=q->value(0).toUInt();
-      diff=::abs(msecs-q->value(1).toInt());
+      diff=::abs(cur_diff);
     }
   }
   delete q;


### PR DESCRIPTION
GCC 6.1.1 defaults to `gnu++14` (C++14 with GNU extensions) as its default C++ standard. This leads to an ambiguity when calling `::abs`, since it can now take `int`, `long`, `long long`, or `__int128` (a GCC 128-bit wide integer type). Since the result of the expression `msecs-q->value(1).toInt()` is unsigned, the compiler must convert it back to a signed type before calling `::abs`.
Since it is assigned to an `int` later on anyway, the most sensible approach is to just assign the result of the expression to an `int` explicitly, which leaves no ambiguities when calling the function.