### PR TITLE
Fixes for MySQL v5.7+ and db creation leftovers

### DIFF
--- a/rdadmin/createdb.cpp
+++ b/rdadmin/createdb.cpp
@@ -1239,7 +1239,6 @@ bool CreateDb(QString name,QString pwd)
   sql="create table if not exists RDAIRPLAY (\
       ID int not null primary key auto_increment,\
       STATION char(40) not null,\
-      INSTANCE int unsigned not null,\
       CARD0 int default 0,\
       PORT0 int default 0,\
       START_RML0 char(255),\
@@ -1351,7 +1350,7 @@ bool CreateDb(QString name,QString pwd)
       LOG2_LOG_LINE int default -1,\
       LOG2_NOW_CART int unsigned default 0,\
       LOG2_NEXT_CART int unsigned default 0,\
-      index STATION_IDX (STATION,INSTANCE))"; 
+      index STATION_IDX (STATION))"; 
   if(!RunQuery(sql)) {
     return false;
   }
@@ -6048,7 +6047,6 @@ int UpdateDb(int ver)
     sql="create table if not exists RDPANEL (\
          ID int not null primary key auto_increment,\
          STATION char(40) not null,\
-         INSTANCE int unsigned not null,\
          CARD2 int default -1,\
          PORT2 int default -1,\
          START_RML2 char(255),\
@@ -6075,7 +6073,7 @@ int UpdateDb(int ver)
          FLASH_PANEL enum('N','Y') default 'N',\
          PANEL_PAUSE_ENABLED enum('N','Y') default 'N',\
          DEFAULT_SERVICE char(10),\
-         index STATION_IDX (STATION,INSTANCE))"; 
+         index STATION_IDX (STATION))"; 
     q=new QSqlQuery(sql);
     delete q;
 

--- a/rdadmin/opendb.cpp
+++ b/rdadmin/opendb.cpp
@@ -240,17 +240,13 @@ and we will try to get this straightened out.");
         if (check_remote_server(host)) {
           host=format_remote_host(host);
         }
-	sql=QString().sprintf("insert into user set Host=\"%s\",\
-            User=\"%s\",Password=PASSWORD(\"%s\")",
-			      (const char *)host, (const char *)login,(const char *)pwd);
+	sql=QString().sprintf("create user %s@'%s' identified by '%s'", 
+	          (const char *)login, (const char *)host, (const char *)pwd);
 	q=new QSqlQuery(sql);
 	delete q;
-	sql=QString().
-	  sprintf("insert into db set Host=\"%s\",Db=\"%s\",\
-            User=\"%s\",Select_priv=\"Y\",Insert_priv=\"Y\",Update_priv=\"Y\",\
-            Delete_priv=\"Y\",Create_priv=\"Y\",Drop_priv=\"Y\",\
-            Index_priv=\"Y\",Alter_priv=\"Y\",Lock_tables_priv=\"Y\"",
-		 (const char *)host, (const char *)dbname,(const char *)login);
+	sql=QString().sprintf("grant SELECT, INSERT, UPDATE, DELETE, CREATE, DROP,\
+	          INDEX, ALTER, LOCK TABLES on %s.* to %s@'%s'", 
+	          (const char *)dbname, (const char *)login, (const char *)host);
 	q=new QSqlQuery(sql);
 	delete q;
 	q=new QSqlQuery("flush privileges");


### PR DESCRIPTION
This converts opendb.cpp to standard create user and grant statements to fix the unable to connect to new db error you get when rdadmin has to create a new database from scratch.

This solves the incompatibilities with MySQL v5.7+ as password has been renamed to authentication string in the user table. I also used grant to apply the same database permissions as the original file, this should help guard against any other changes that might happen in the future.

This is compatible with earlier versions of MySQL for as far back as I can remember.

See issue #123 for more info.

This also fixes the rdairplay password prompts and the rdpanel segfault if you create a db from scratch.  This is because INSTANCE is a left over from before schema 219 and doesn't get removed as part of a new db, see issue #129 for more info.