### PR TITLE
MySQL v5.7+ Date/Time changes (RDCheckDateTime)

### DIFF
--- a/importers/rivendell_filter.cpp
+++ b/importers/rivendell_filter.cpp
@@ -274,7 +274,7 @@ MainObject::MainObject(QObject *parent)
                            TITLE=\"%s\",\
                            ARTIST=\"%s\",\
                            ALBUM=\"%s\",\
-                           YEAR=\"%s\",\
+                           YEAR=%s,\
                            ISRC=\"%s\",\
                            LABEL=\"%s\",\
                            CLIENT=\"%s\",\
@@ -347,7 +347,7 @@ MainObject::MainObject(QObject *parent)
 	start_datetime="null";
       }
       else {
-	start_datetime=QString().sprintf("\"%s\"",
+	start_datetime=QString().sprintf("%s",
 			(const char *)RDCheckDateTime(q1->value(7).
 			toDateTime(),"yyyy-MM-dd hh:mm:ss"));//Could be invalid (0000-00-00)
       }
@@ -355,7 +355,7 @@ MainObject::MainObject(QObject *parent)
 	end_datetime="null";
       }
       else {
-	end_datetime=QString().sprintf("\"%s\"",
+	end_datetime=QString().sprintf("%s",
 			(const char *)RDCheckDateTime(q1->value(8).
 			toDateTime(),"yyyy-MM-dd hh:mm:ss"));//Could be invalid (0000-00-00)
       }
@@ -363,7 +363,7 @@ MainObject::MainObject(QObject *parent)
 	start_daypart="null";
       }
       else {
-	start_daypart=QString().sprintf("\"%s\"",
+	start_daypart=QString().sprintf("%s",
 					(const char *)RDCheckDateTime(q1->value(16).
 					toTime(),"hh:mm:ss"));//Invalid possible?
       }
@@ -371,7 +371,7 @@ MainObject::MainObject(QObject *parent)
 	end_daypart="null";
       }
       else {
-	end_daypart=QString().sprintf("\"%s\"",
+	end_daypart=QString().sprintf("%s",
 					(const char *)RDCheckDateTime(q1->value(17).
 					toTime(),"hh:mm:ss"));//Invalid possible?
       }

--- a/importers/rivendell_filter.cpp
+++ b/importers/rivendell_filter.cpp
@@ -304,8 +304,7 @@ MainObject::MainObject(QObject *parent)
 			  (const char *)RDEscapeString(q->value(3).toString()),
 			  (const char *)RDEscapeString(q->value(4).toString()),
 			  (const char *)RDEscapeString(q->value(5).toString()),
-			  (const char *)q->value(6).toDate().
-			  toString("yyyy-MM-dd"),
+			  (const char *)RDCheckDateTime(q->value(6).toDate(),"yyyy-MM-dd"),
 			  (const char *)RDEscapeString(q->value(7).toString()),
 			  (const char *)RDEscapeString(q->value(8).toString()),
 			  (const char *)RDEscapeString(q->value(9).toString()),
@@ -349,32 +348,32 @@ MainObject::MainObject(QObject *parent)
       }
       else {
 	start_datetime=QString().sprintf("\"%s\"",
-			(const char *)q1->value(7).
-			toDateTime().toString("yyyy-MM-dd hh:mm:ss"));
+			(const char *)RDCheckDateTime(q1->value(7).
+			toDateTime(),"yyyy-MM-dd hh:mm:ss"));//Could be invalid (0000-00-00)
       }
       if(q1->value(8).isNull()) {
 	end_datetime="null";
       }
       else {
 	end_datetime=QString().sprintf("\"%s\"",
-			(const char *)q1->value(8).
-			toDateTime().toString("yyyy-MM-dd hh:mm:ss"));
+			(const char *)RDCheckDateTime(q1->value(8).
+			toDateTime(),"yyyy-MM-dd hh:mm:ss"));//Could be invalid (0000-00-00)
       }
       if(q1->value(16).isNull()) {
 	start_daypart="null";
       }
       else {
 	start_daypart=QString().sprintf("\"%s\"",
-					(const char *)q1->value(16).
-					toTime().toString("hh:mm:ss"));
+					(const char *)RDCheckDateTime(q1->value(16).
+					toTime(),"hh:mm:ss"));//Invalid possible?
       }
       if(q1->value(17).isNull()) {
 	end_daypart="null";
       }
       else {
 	end_daypart=QString().sprintf("\"%s\"",
-					(const char *)q1->value(17).
-					toTime().toString("hh:mm:ss"));
+					(const char *)RDCheckDateTime(q1->value(17).
+					toTime(),"hh:mm:ss"));//Invalid possible?
       }
       sql=QString().sprintf("insert into CUTS set CART_NUMBER=%u,\
                              CUT_NAME=\"%s\",\

--- a/lib/rdcart.cpp
+++ b/lib/rdcart.cpp
@@ -1207,14 +1207,14 @@ void RDCart::updateLength(bool enforce_length,unsigned length)
   }
   else {
     sql+=QString().sprintf("START_DATETIME=\"%s\",",
-		(const char *)start_datetime.toString("yyyy-MM-dd hh:mm:ss"));
+		(const char *)RDCheckDateTime(start_datetime,"yyyy-MM-dd hh:mm:ss"));
   }
   if(end_datetime.isNull()||(!dates_valid)) {
     sql+="END_DATETIME=NULL,";
   }
   else {
     sql+=QString().sprintf("END_DATETIME=\"%s\",",
-		(const char *)end_datetime.toString("yyyy-MM-dd hh:mm:ss"));
+		(const char *)RDCheckDateTime(end_datetime,"yyyy-MM-dd hh:mm:ss"));
   }
   sql+=QString().sprintf("VALIDITY=%u where NUMBER=%u",
 			 cart_validity,cart_number);
@@ -1740,7 +1740,7 @@ void RDCart::SetRow(const QString &param,const QDateTime &value) const
 
   sql=QString().sprintf("UPDATE CART SET %s=\"%s\" WHERE NUMBER=%u",
 			(const char *)param,
-			(const char *)value.toString("yyyy-MM-dd hh:mm:ss"),
+			(const char *)RDCheckDateTime(value,"yyyy-MM-dd hh:mm:ss"),
 			cart_number);
   q=new RDSqlQuery(sql);
   delete q;
@@ -1754,7 +1754,7 @@ void RDCart::SetRow(const QString &param,const QDate &value) const
 
   sql=QString().sprintf("UPDATE CART SET %s=\"%s\" WHERE NUMBER=%u",
 			(const char *)param,
-			(const char *)value.toString("yyyy-MM-dd"),
+			(const char *)RDCheckDateTime(value,"yyyy-MM-dd"),
 			cart_number);
   q=new RDSqlQuery(sql);
   delete q;

--- a/lib/rdcart.cpp
+++ b/lib/rdcart.cpp
@@ -1206,14 +1206,14 @@ void RDCart::updateLength(bool enforce_length,unsigned length)
     sql+="START_DATETIME=NULL,";
   }
   else {
-    sql+=QString().sprintf("START_DATETIME=\"%s\",",
+    sql+=QString().sprintf("START_DATETIME=%s,",
 		(const char *)RDCheckDateTime(start_datetime,"yyyy-MM-dd hh:mm:ss"));
   }
   if(end_datetime.isNull()||(!dates_valid)) {
     sql+="END_DATETIME=NULL,";
   }
   else {
-    sql+=QString().sprintf("END_DATETIME=\"%s\",",
+    sql+=QString().sprintf("END_DATETIME=%s,",
 		(const char *)RDCheckDateTime(end_datetime,"yyyy-MM-dd hh:mm:ss"));
   }
   sql+=QString().sprintf("VALIDITY=%u where NUMBER=%u",
@@ -1738,7 +1738,7 @@ void RDCart::SetRow(const QString &param,const QDateTime &value) const
   RDSqlQuery *q;
   QString sql;
 
-  sql=QString().sprintf("UPDATE CART SET %s=\"%s\" WHERE NUMBER=%u",
+  sql=QString().sprintf("UPDATE CART SET %s=%s WHERE NUMBER=%u",
 			(const char *)param,
 			(const char *)RDCheckDateTime(value,"yyyy-MM-dd hh:mm:ss"),
 			cart_number);
@@ -1752,7 +1752,7 @@ void RDCart::SetRow(const QString &param,const QDate &value) const
   RDSqlQuery *q;
   QString sql;
 
-  sql=QString().sprintf("UPDATE CART SET %s=\"%s\" WHERE NUMBER=%u",
+  sql=QString().sprintf("UPDATE CART SET %s=%s WHERE NUMBER=%u",
 			(const char *)param,
 			(const char *)RDCheckDateTime(value,"yyyy-MM-dd"),
 			cart_number);

--- a/lib/rdcartslot.cpp
+++ b/lib/rdcartslot.cpp
@@ -670,7 +670,7 @@ void RDCartSlot::LogPlayout(RDPlayDeck::State state)
     datetime.setDate(datetime.date().addDays(-1));
   }
   if(!slot_svcname.isEmpty()) {
-    QDateTime eventDateTime=QDateTime::QDateTime(datetime::date(), 
+    QDateTime eventDateTime(datetime.date(), 
           slot_logline->startTime(RDLogLine::Actual));
     QString svctablename=slot_svcname;
     svctablename.replace(" ","_");

--- a/lib/rdcartslot.cpp
+++ b/lib/rdcartslot.cpp
@@ -688,16 +688,18 @@ void RDCartSlot::LogPlayout(RDPlayDeck::State state)
 			slot_logline->startSource())+
       "STATION_NAME=\""+RDEscapeString(slot_station->name())+"\","+
       "EVENT_DATETIME=\""+datetime.toString("yyyy-MM-dd")+
-      " "+slot_logline->startTime(RDLogLine::Actual).toString("hh:mm:ss")+"\","+
-      "EXT_START_TIME=\""+slot_logline->extStartTime().toString("hh:mm:ss")+"\","+
+      " "+RDCheckDateTime(
+    		  slot_logline->startTime(RDLogLine::Actual),"hh:mm:ss")+"\","+
+      "EXT_START_TIME=\""+RDCheckDateTime(
+    		  slot_logline->extStartTime(),"hh:mm:ss")+"\","+
       "EXT_DATA=\""+RDEscapeString(slot_logline->extData())+"\","+
       "EXT_EVENT_ID=\""+RDEscapeString(slot_logline->extEventId())+"\","+
       "EXT_ANNC_TYPE=\""+RDEscapeString(slot_logline->extAnncType())+"\","+
       "EXT_CART_NAME=\""+RDEscapeString(slot_logline->extCartName())+"\","+
       "TITLE=\""+RDEscapeString(slot_logline->title())+"\","+
       "ARTIST=\""+RDEscapeString(slot_logline->artist())+"\","+
-      "SCHEDULED_TIME=\""+slot_logline->startTime(RDLogLine::Logged).
-      toString("hh:mm:ss")+"\","+
+      "SCHEDULED_TIME=\""+RDCheckDateTime(
+    		slot_logline->startTime(RDLogLine::Logged),"hh:mm:ss")+"\","+
       "ISRC=\""+RDEscapeString(slot_logline->isrc())+"\","+
       "PUBLISHER=\""+RDEscapeString(slot_logline->publisher())+"\","+
       "COMPOSER=\""+RDEscapeString(slot_logline->composer())+"\","+

--- a/lib/rdcartslot.cpp
+++ b/lib/rdcartslot.cpp
@@ -670,6 +670,8 @@ void RDCartSlot::LogPlayout(RDPlayDeck::State state)
     datetime.setDate(datetime.date().addDays(-1));
   }
   if(!slot_svcname.isEmpty()) {
+    QDateTime eventDateTime=QDateTime::QDateTime(datetime::date(), 
+          slot_logline->startTime(RDLogLine::Actual));
     QString svctablename=slot_svcname;
     svctablename.replace(" ","_");
     sql=QString("insert into `")+svctablename+"_SRT` set "+
@@ -687,19 +689,18 @@ void RDCartSlot::LogPlayout(RDPlayDeck::State state)
 			slot_logline->usageCode(),
 			slot_logline->startSource())+
       "STATION_NAME=\""+RDEscapeString(slot_station->name())+"\","+
-      "EVENT_DATETIME=\""+datetime.toString("yyyy-MM-dd")+
-      " "+RDCheckDateTime(
-    		  slot_logline->startTime(RDLogLine::Actual),"hh:mm:ss")+"\","+
-      "EXT_START_TIME=\""+RDCheckDateTime(
-    		  slot_logline->extStartTime(),"hh:mm:ss")+"\","+
+      "EVENT_DATETIME="+RDCheckDateTime(eventDateTime,"yyyy-MM-dd hh:mm:ss")+
+      ","+
+      "EXT_START_TIME="+RDCheckDateTime(
+    		  slot_logline->extStartTime(),"hh:mm:ss")+","+
       "EXT_DATA=\""+RDEscapeString(slot_logline->extData())+"\","+
       "EXT_EVENT_ID=\""+RDEscapeString(slot_logline->extEventId())+"\","+
       "EXT_ANNC_TYPE=\""+RDEscapeString(slot_logline->extAnncType())+"\","+
       "EXT_CART_NAME=\""+RDEscapeString(slot_logline->extCartName())+"\","+
       "TITLE=\""+RDEscapeString(slot_logline->title())+"\","+
       "ARTIST=\""+RDEscapeString(slot_logline->artist())+"\","+
-      "SCHEDULED_TIME=\""+RDCheckDateTime(
-    		slot_logline->startTime(RDLogLine::Logged),"hh:mm:ss")+"\","+
+      "SCHEDULED_TIME="+RDCheckDateTime(
+    		slot_logline->startTime(RDLogLine::Logged),"hh:mm:ss")+","+
       "ISRC=\""+RDEscapeString(slot_logline->isrc())+"\","+
       "PUBLISHER=\""+RDEscapeString(slot_logline->publisher())+"\","+
       "COMPOSER=\""+RDEscapeString(slot_logline->composer())+"\","+

--- a/lib/rdcut.cpp
+++ b/lib/rdcut.cpp
@@ -1095,7 +1095,7 @@ void RDCut::setMetadata(RDWaveData *data) const
       startDateTime.setTime(QTime(0,0,0));
       
     sql+=QString().sprintf("START_DATETIME=%s,",
-        (const char *)RDCheckDateTime(startDateTime));
+        (const char *)RDCheckDateTime(startDateTime,"yyyy-MM-dd hh:mm:ss"));
       
     if(data->endDate().isValid()&&(data->endDate().year()<8000)) {
       

--- a/lib/rdcut.cpp
+++ b/lib/rdcut.cpp
@@ -1060,8 +1060,8 @@ void RDCut::setMetadata(RDWaveData *data) const
   }
   if(data->daypartStartTime().isValid()&&data->daypartEndTime().isValid()&&
      (data->daypartStartTime()<data->daypartEndTime())) {
-    sql+="START_DAYPART=\""+data->daypartStartTime().toString("hh:mm:ss")+"\","+
-      "END_DAYPART=\""+data->daypartEndTime().toString("hh:mm:ss")+"\",";
+    sql+="START_DAYPART=\""+RDCheckDateTime(data->daypartStartTime(),"hh:mm:ss")+"\","+
+      "END_DAYPART=\""+RDCheckDateTime(data->daypartEndTime(),"hh:mm:ss")+"\",";
   }
   if((data->hookStartPos()>=data->startPos())&&
      (data->hookStartPos()<=data->endPos())&&
@@ -1082,28 +1082,22 @@ void RDCut::setMetadata(RDWaveData *data) const
   if((data->startDate()>QDate(1900,1,1))&&(data->endDate().year()<8000)) {
     if(data->startTime().isValid()) {
     sql+=QString().sprintf("START_DATETIME=\"%s %s\",",
-			   (const char *)data->startDate().
-			   toString("yyyy-MM-dd"),
-			   (const char *)data->startTime().
-			   toString("hh:mm:ss"));
+			   (const char *)RDCheckDateTime(data->startDate(),"yyyy-MM-dd"),
+			   (const char *)RDCheckDateTime(data->startTime(),"hh:mm:ss"));
     }
     else {
       sql+=QString().sprintf("START_DATETIME=\"%s 00:00:00\",",
-			     (const char *)data->startDate().
-			     toString("yyyy-MM-dd"));
+			     (const char *)RDCheckDateTime(data->startDate(),"yyyy-MM-dd"));
     }
     if(data->endDate().isValid()&&(data->endDate().year()<8000)) {
       if(data->endTime().isValid()) {
 	sql+=QString().sprintf("END_DATETIME=\"%s %s\",",
-			       (const char *)data->endDate().
-			       toString("yyyy-MM-dd"),
-			       (const char *)data->endTime().
-			       toString("hh:mm:ss"));
+			       (const char *)RDCheckDateTime(data->endDate(),"yyyy-MM-dd"),
+			       (const char *)RDCheckDateTime(data->endTime(),"hh:mm:ss"));
       }
       else {
 	sql+=QString().sprintf("END_DATETIME=\"%s 23:59:59\",",
-			       (const char *)data->endDate().
-			       toString("yyyy-MM-dd"));
+			       (const char *)RDCheckDateTime(data->endDate(),"yyyy-MM-dd"));
       }
     }
   }
@@ -1605,7 +1599,7 @@ void RDCut::SetRow(const QString &param,const QDateTime &value) const
 
   sql=QString().sprintf("UPDATE CUTS SET %s=\"%s\" WHERE CUT_NAME=\"%s\"",
 			(const char *)param,
-			(const char *)value.toString("yyyy-MM-dd hh:mm:ss"),
+			(const char *)RDCheckDateTime(value,"yyyy-MM-dd hh:mm:ss"),
 			(const char *)cut_name);
   q=new RDSqlQuery(sql,cut_db);
   delete q;
@@ -1619,7 +1613,7 @@ void RDCut::SetRow(const QString &param,const QDate &value) const
 
   sql=QString().sprintf("UPDATE CUTS SET %s=\"%s\" WHERE CUT_NAME=\"%s\"",
 			(const char *)param,
-			(const char *)value.toString("yyyy-MM-dd"),
+			(const char *)RDCheckDateTime(value,"yyyy-MM-dd"),
 			(const char *)cut_name);
   q=new RDSqlQuery(sql,cut_db);
   delete q;
@@ -1632,7 +1626,7 @@ void RDCut::SetRow(const QString &param,const QTime &value) const
   QString sql;
   sql=QString().sprintf("UPDATE CUTS SET %s=\"%s\" WHERE CUT_NAME=\"%s\"",
 			(const char *)param,
-			(const char *)value.toString("hh:mm:ss"),
+			(const char *)RDCheckDateTime(value,"hh:mm:ss"),
 			(const char *)cut_name);
   q=new RDSqlQuery(sql,cut_db);
   delete q;

--- a/lib/rdescape_string.cpp
+++ b/lib/rdescape_string.cpp
@@ -34,7 +34,7 @@ QString RDCheckDateTime(QTime const &time, QString const &format)
   QString checkedValue = "NULL";
   
   if(time.isValid())
-    checkedValue = time.toString(format);
+    checkedValue = "\"" + time.toString(format) + "\"";
   
   return checkedValue;
   
@@ -51,7 +51,7 @@ QString RDCheckDateTime(QDateTime const &datetime, QString const &format)
   QString checkedValue = "NULL";
   
   if(datetime.isValid())
-    checkedValue = datetime.toString(format);
+    checkedValue = "\"" + datetime.toString(format) + "\"";
   
   return checkedValue;
   
@@ -68,7 +68,7 @@ QString RDCheckDateTime(QDate const &date, QString const &format)
   QString checkedValue = "NULL";
   
   if(date.isValid())
-    checkedValue = date.toString(format);
+    checkedValue = "\"" + date.toString(format) + "\"";
   
   return checkedValue;
   

--- a/lib/rdescape_string.cpp
+++ b/lib/rdescape_string.cpp
@@ -21,6 +21,58 @@
 #include <vector>
 
 #include <rdescape_string.h>
+#include <qdatetime.h>
+
+/**
+ * RDCheckDateTime - Checks for QTime.isValid 
+ * @param time - QTime object
+ * @param format - QString representing time format e.g. HH:MM
+ * @return QString, "NULL" if not Valid else formatted Time String
+ */
+QString RDCheckDateTime(QTime const &time, QString const &format)
+{
+  QString checkedValue = "NULL";
+  
+  if(time.isValid())
+    checkedValue = time.toString(format);
+  
+  return checkedValue;
+  
+}
+
+/**
+ * RDCheckDateTime - Checks for QDateTime.isValid 
+ * @param datetime - QDateTime object
+ * @param format - QString representing date time format e.g. yyyy-mm-dd HH:MM
+ * @return QString, "NULL" if not Valid else formatted DateTime String
+ */
+QString RDCheckDateTime(QDateTime const &datetime, QString const &format)
+{
+  QString checkedValue = "NULL";
+  
+  if(datetime.isValid())
+    checkedValue = datetime.toString(format);
+  
+  return checkedValue;
+  
+}
+
+/**
+ * RDCheckDateTime - Checks for QDate.isValid 
+ * @param date - QDate object
+ * @param format - QString representing date format e.g. yyyy-mm-dd
+ * @return QString, "NULL" if not Valid else formatted Date String
+ */
+QString RDCheckDateTime(QDate const &date, QString const &format)
+{
+  QString checkedValue = "NULL";
+  
+  if(date.isValid())
+    checkedValue = date.toString(format);
+  
+  return checkedValue;
+  
+}
 
 QString RDEscapeString(QString const &str)
 {

--- a/lib/rdescape_string.h
+++ b/lib/rdescape_string.h
@@ -19,11 +19,16 @@
 //
 
 #include <qstring.h>
+#include <qdatetime.h>
 
 #ifndef RDESCAPE_STRING_H
 #define RDESCAPE_STRING_H
 
+QString RDCheckDateTime(const QTime &time, const QString &format);
+QString RDCheckDateTime(const QDateTime &datetime, const QString &format);
+QString RDCheckDateTime(const QDate &date, const QString &format);
 QString RDEscapeString(const QString &str);
+
 
 
 #endif  // RDESCAPE_STRING_H

--- a/lib/rdevent_line.cpp
+++ b/lib/rdevent_line.cpp
@@ -814,7 +814,7 @@ bool RDEventLine::generateLog(QString logname,const QString &svcname,
       sql=QString().sprintf("insert into `%s_LOG` set ID=%d,COUNT=%d,TYPE=%d,\
 			     SOURCE=%d,START_TIME=%d,GRACE_TIME=%d, \
 			     CART_NUMBER=%u,TIME_TYPE=%d,POST_POINT=\"%s\", \
-			     TRANS_TYPE=%d,EXT_START_TIME=\"%s\",\
+			     TRANS_TYPE=%d,EXT_START_TIME=%s,\
                              EVENT_LENGTH=%d",
 			    (const char *)logname,count,count,
 			    RDLogLine::Cart,source,

--- a/lib/rdevent_line.cpp
+++ b/lib/rdevent_line.cpp
@@ -824,7 +824,7 @@ bool RDEventLine::generateLog(QString logname,const QString &svcname,
 			    time_type,
 			    (const char *)RDYesNo(post_point),
 			    trans_type,
-			    (const char *)time.toString("hh:mm:ss"),
+			    (const char *)RDCheckDateTime(time,"hh:mm:ss"),
 			    event_length);
       q=new RDSqlQuery(sql);
       delete q;

--- a/lib/rdfeed.cpp
+++ b/lib/rdfeed.cpp
@@ -320,7 +320,7 @@ QDateTime RDFeed::lastBuildDateTime() const
 
 void RDFeed::setLastBuildDateTime(const QDateTime &datetime) const
 {
-  SetRow("LAST_BUILD_DATETIME",datetime.toString("yyyy-MM-dd hh:mm:ss"));
+  SetRow("LAST_BUILD_DATETIME",RDCheckDateTime(datetime,"yyyy-MM-dd hh:mm:ss"));
 }
 
 
@@ -333,7 +333,7 @@ QDateTime RDFeed::originDateTime() const
 
 void RDFeed::setOriginDateTime(const QDateTime &datetime) const
 {
-  SetRow("ORIGIN_DATETIME",datetime.toString("yyyy-MM-dd hh:mm:ss"));
+  SetRow("ORIGIN_DATETIME",RDCheckDateTime(datetime,"yyyy-MM-dd hh:mm:ss"));
 }
 
 

--- a/lib/rdfeed.cpp
+++ b/lib/rdfeed.cpp
@@ -898,7 +898,7 @@ void RDFeed::SetRow(const QString &param,const QString &value) const
 }
 
 void RDFeed::SetRow(const QString &param,const QDateTime &value,
-                    const QString format) const
+                    const QString &format) const
 {
   RDSqlQuery *q;
   QString sql;

--- a/lib/rdfeed.cpp
+++ b/lib/rdfeed.cpp
@@ -320,7 +320,7 @@ QDateTime RDFeed::lastBuildDateTime() const
 
 void RDFeed::setLastBuildDateTime(const QDateTime &datetime) const
 {
-  SetRow("LAST_BUILD_DATETIME",RDCheckDateTime(datetime,"yyyy-MM-dd hh:mm:ss"));
+  SetRow("LAST_BUILD_DATETIME",datetime,"yyyy-MM-dd hh:mm:ss");
 }
 
 
@@ -333,7 +333,7 @@ QDateTime RDFeed::originDateTime() const
 
 void RDFeed::setOriginDateTime(const QDateTime &datetime) const
 {
-  SetRow("ORIGIN_DATETIME",RDCheckDateTime(datetime,"yyyy-MM-dd hh:mm:ss"));
+  SetRow("ORIGIN_DATETIME",datetime,"yyyy-MM-dd hh:mm:ss");
 }
 
 
@@ -892,6 +892,20 @@ void RDFeed::SetRow(const QString &param,const QString &value) const
   sql=QString().sprintf("UPDATE FEEDS SET %s=\"%s\" WHERE KEY_NAME=\"%s\"",
 			(const char *)param,
 			(const char *)RDEscapeString(value),
+			(const char *)feed_keyname);
+  q=new RDSqlQuery(sql);
+  delete q;
+}
+
+void RDFeed::SetRow(const QString &param,const QDateTime &value,
+                    const QString format) const
+{
+  RDSqlQuery *q;
+  QString sql;
+
+  sql=QString().sprintf("UPDATE FEEDS SET %s=%s WHERE KEY_NAME=\"%s\"",
+			(const char *)param,
+			(const char *)RDCheckDateTime(value, format),
 			(const char *)feed_keyname);
   q=new RDSqlQuery(sql);
   delete q;

--- a/lib/rdfeed.h
+++ b/lib/rdfeed.h
@@ -123,6 +123,8 @@ class RDFeed : public QObject
   QString GetTempFilename() const;
   void SetRow(const QString &param,int value) const;
   void SetRow(const QString &param,const QString &value) const;
+  void SetRow(const QString &param,const QDateTime &value,
+              const QString &format) const;
   QString feed_keyname;
   unsigned feed_id;
 };

--- a/lib/rdlog.cpp
+++ b/lib/rdlog.cpp
@@ -661,7 +661,7 @@ void RDLog::SetRow(const QString &param,const QDate &value) const
   RDSqlQuery *q;
   QString sql;
 
-  sql=QString().sprintf("UPDATE LOGS SET %s=\"%s\" WHERE NAME=\"%s\"",
+  sql=QString().sprintf("UPDATE LOGS SET %s=%s WHERE NAME=\"%s\"",
 			(const char *)param,
 			(const char *)RDCheckDateTime(value,"yyyy/MM/dd"),
 			(const char *)RDEscapeString(log_name));
@@ -675,7 +675,7 @@ void RDLog::SetRow(const QString &param,const QDateTime &value) const
   RDSqlQuery *q;
   QString sql;
 
-  sql=QString().sprintf("UPDATE LOGS SET %s=\"%s\" WHERE NAME=\"%s\"",
+  sql=QString().sprintf("UPDATE LOGS SET %s=%s WHERE NAME=\"%s\"",
 			(const char *)param,
 			(const char *)RDCheckDateTime(value,"yyyy-MM-dd hh:mm:ss"),
 			(const char *)RDEscapeString(log_name));

--- a/lib/rdlog.cpp
+++ b/lib/rdlog.cpp
@@ -663,7 +663,7 @@ void RDLog::SetRow(const QString &param,const QDate &value) const
 
   sql=QString().sprintf("UPDATE LOGS SET %s=\"%s\" WHERE NAME=\"%s\"",
 			(const char *)param,
-			(const char *)value.toString("yyyy/MM/dd"),
+			(const char *)RDCheckDateTime(value,"yyyy/MM/dd"),
 			(const char *)RDEscapeString(log_name));
   q=new RDSqlQuery(sql);
   delete q;
@@ -677,7 +677,7 @@ void RDLog::SetRow(const QString &param,const QDateTime &value) const
 
   sql=QString().sprintf("UPDATE LOGS SET %s=\"%s\" WHERE NAME=\"%s\"",
 			(const char *)param,
-			(const char *)value.toString("yyyy-MM-dd hh:mm:ss"),
+			(const char *)RDCheckDateTime(value,"yyyy-MM-dd hh:mm:ss"),
 			(const char *)RDEscapeString(log_name));
   q=new RDSqlQuery(sql);
   delete q;

--- a/lib/rdlog_event.cpp
+++ b/lib/rdlog_event.cpp
@@ -1186,7 +1186,7 @@ void RDLogEvent::InsertLines(QString values) {
 void RDLogEvent::InsertLineValues(QString *query, int line)
 {
   // one line to save query space
-  QString sql=QString().sprintf("(%d,%d,%u,%d,%d,%d,%d,%d,%d,%d,%d,\"%s\",\"%s\",%d,%d,\"%s\",%d,\"%s\",\"%s\",\"%s\",\"%s\",%d,%d,%d,%d,%d,\"%s\",%d,%d,%d,\"%s\",\"%s\",\"%s\",%d,%d,%d,%d,%d)",
+  QString sql=QString().sprintf("(%d,%d,%u,%d,%d,%d,%d,%d,%d,%d,%d,\"%s\",\"%s\",%d,%d,%s,%d,\"%s\",\"%s\",\"%s\",\"%s\",%d,%d,%d,%d,%d,\"%s\",%d,%d,%d,\"%s\",\"%s\",%s,%d,%d,%d,%d,%d)",
                         log_line[line]->id(),
                         line,
                         log_line[line]->cartNumber(),

--- a/lib/rdlog_event.cpp
+++ b/lib/rdlog_event.cpp
@@ -244,6 +244,7 @@ int RDLogEvent::validate(QString *report,const QDate &date)
 	    //
 	    // Handle events with no logged start time (e.g. manual inserts)
 	    //
+		//TODO do we need to verify date here?
 	    sql=QString().
 	      sprintf("select CUT_NAME from CUTS where \
                       (CART_NUMBER=%u)&&			\
@@ -258,6 +259,7 @@ int RDLogEvent::validate(QString *report,const QDate &date)
 		      (const char *)RDDowCode(date.dayOfWeek()));
 	  }
 	  else {
+		//TODO Do we need to verify date and logLine(i)->startTime?
 	    sql=QString().
 	      sprintf("select CUT_NAME from CUTS where \
                      (CART_NUMBER=%u)&&					\
@@ -1203,8 +1205,8 @@ void RDLogEvent::InsertLineValues(QString *query, int line)
                         RDEscapeString(log_line[line]->markerLabel()),
                         log_line[line]->graceTime(),
                         log_line[line]->source(),
-                        (const char *)log_line[line]->extStartTime().
-                        toString("hh:mm:ss"),
+                        (const char *)RDCheckDateTime(
+                        		log_line[line]->extStartTime(),"hh:mm:ss"),
                         log_line[line]->extLength(),
                         (const char *)RDEscapeString(log_line[line]->extData()),
                         (const char *)
@@ -1226,8 +1228,8 @@ void RDLogEvent::InsertLineValues(QString *query, int line)
                         (const char *)RDYesNo(log_line[line]->linkEmbedded()),
                         (const char *)
                         RDEscapeString(log_line[line]->originUser()),
-                        (const char *)log_line[line]->originDateTime().
-                        toString("yyyy-MM-dd hh:mm:ss"),
+                        (const char *)RDCheckDateTime(
+                        log_line[line]->originDateTime(),"yyyy-MM-dd hh:mm:ss"),
                         log_line[line]->linkStartSlop(),
                         log_line[line]->linkEndSlop(),
                         log_line[line]->duckUpGain(),

--- a/lib/rdpodcast.cpp
+++ b/lib/rdpodcast.cpp
@@ -209,7 +209,7 @@ QDateTime RDPodcast::originDateTime() const
 
 void RDPodcast::setOriginDateTime(const QDateTime &datetime) const
 {
-  SetRow("ORIGIN_DATETIME",RDCheckDateTime(datetime,"yyyy-MM-dd hh:mm:ss"));
+  SetRow("ORIGIN_DATETIME",datetime,"yyyy-MM-dd hh:mm:ss");
 }
 
 
@@ -222,7 +222,7 @@ QDateTime RDPodcast::effectiveDateTime() const
 
 void RDPodcast::setEffectiveDateTime(const QDateTime &datetime) const
 {
-  SetRow("EFFECTIVE_DATETIME",RDCheckDateTime(datetime,"yyyy-MM-dd hh:mm:ss"));
+  SetRow("EFFECTIVE_DATETIME",datetime,"yyyy-MM-dd hh:mm:ss");
 }
 
 
@@ -394,6 +394,21 @@ void RDPodcast::SetRow(const QString &param,const QString &value) const
   sql=QString().sprintf("UPDATE PODCASTS SET %s=\"%s\" WHERE ID=%u",
 			(const char *)param,
 			(const char *)RDEscapeString(value),
+			podcast_id);
+  q=new RDSqlQuery(sql);
+  delete q;
+}
+
+
+void RDPodcast::SetRow(const QString &param,const QDateTime &value,
+                       const QString &format) const
+{
+  RDSqlQuery *q;
+  QString sql;
+
+  sql=QString().sprintf("UPDATE PODCASTS SET %s=%s WHERE ID=%u",
+			(const char *)param,
+			(const char *)RDCheckDateTime(value, format),
 			podcast_id);
   q=new RDSqlQuery(sql);
   delete q;

--- a/lib/rdpodcast.cpp
+++ b/lib/rdpodcast.cpp
@@ -209,7 +209,7 @@ QDateTime RDPodcast::originDateTime() const
 
 void RDPodcast::setOriginDateTime(const QDateTime &datetime) const
 {
-  SetRow("ORIGIN_DATETIME",datetime.toString("yyyy-MM-dd hh:mm:ss"));
+  SetRow("ORIGIN_DATETIME",RDCheckDateTime(datetime,"yyyy-MM-dd hh:mm:ss"));
 }
 
 
@@ -222,7 +222,7 @@ QDateTime RDPodcast::effectiveDateTime() const
 
 void RDPodcast::setEffectiveDateTime(const QDateTime &datetime) const
 {
-  SetRow("EFFECTIVE_DATETIME",datetime.toString("yyyy-MM-dd hh:mm:ss"));
+  SetRow("EFFECTIVE_DATETIME",RDCheckDateTime(datetime,"yyyy-MM-dd hh:mm:ss"));
 }
 
 

--- a/lib/rdpodcast.h
+++ b/lib/rdpodcast.h
@@ -76,6 +76,7 @@ class RDPodcast
  private:
   void SetRow(const QString &param,int value) const;
   void SetRow(const QString &param,const QString &value) const;
+  void SetRow(const QString &param,const QDateTime &datetime,const QString &value) const;
   QString podcast_keyname;
   unsigned podcast_id;
 };

--- a/lib/rdrecording.cpp
+++ b/lib/rdrecording.cpp
@@ -945,7 +945,7 @@ void RDRecording::SetRow(const QString &param,const QTime &value) const
   RDSqlQuery *q;
   QString sql;
 
-  sql=QString().sprintf("update RECORDINGS set %s=\"%s\" where ID=%d",
+  sql=QString().sprintf("update RECORDINGS set %s=%s where ID=%d",
 			(const char *)param,
 			(const char *)RDCheckDateTime(value,"hh:mm:ss"),rec_id);
   q=new RDSqlQuery(sql);

--- a/lib/rdrecording.cpp
+++ b/lib/rdrecording.cpp
@@ -947,7 +947,7 @@ void RDRecording::SetRow(const QString &param,const QTime &value) const
 
   sql=QString().sprintf("update RECORDINGS set %s=\"%s\" where ID=%d",
 			(const char *)param,
-			(const char *)value.toString("hh:mm:ss"),rec_id);
+			(const char *)RDCheckDateTime(value,"hh:mm:ss"),rec_id);
   q=new RDSqlQuery(sql);
   delete q;
 }

--- a/lib/rdreport.cpp
+++ b/lib/rdreport.cpp
@@ -347,20 +347,19 @@ bool RDReport::generateReport(const QDate &startdate,const QDate &enddate,
       QDate date=startdate.addDays(i);
       if(startTime()<endTime()) {
 	daypart_sql+=QString("((EVENT_DATETIME>=\"")+
-	  date.toString("yyyy-MM-dd")+
-	  " "+startTime().toString("hh:mm:ss")+"\")&&"+
-	  "(EVENT_DATETIME<\""+date.toString("yyyy-MM-dd")+
-	  " "+endTime().toString("hh:mm:ss")+"\"))||";
+	  RDCheckDateTime(date,"yyyy-MM-dd")+
+	  " "+RDCheckDateTime(startTime(),"hh:mm:ss")+"\")&&"+
+	  "(EVENT_DATETIME<\""+RDCheckDateTime(date,"yyyy-MM-dd")+
+	  " "+RDCheckDateTime(endTime(),"hh:mm:ss")+"\"))||";
       }
       else {
 	daypart_sql+=QString("((EVENT_DATETIME<=\"")+
-	  date.toString("yyyy-MM-dd")+
-	  " "+endTime().toString("hh:mm:ss")+"\")&&"+
-	  "(EVENT_DATETIME>\""+date.toString("yyyy-MM-dd")+" 00:00:00))||"+
-	  "((EVENT_DATETIME>=\""+
-	  date.toString("yyyy-MM-dd")+
-	  " "+startTime().toString("hh:mm:ss")+"\")&&"+
-	  "(EVENT_DATETIME<\""+date.toString("yyyy-MM-dd")+" 23:59:59))||";
+	  RDCheckDateTime(date,"yyyy-MM-dd")+
+	  " "+RDCheckDateTime(endTime(),"hh:mm:ss")+"\")&&"+
+	  "(EVENT_DATETIME>\""+RDCheckDateTime(date,"yyyy-MM-dd")+" 00:00:00))||"+
+	  "((EVENT_DATETIME>=\""+RDCheckDateTime(date,"yyyy-MM-dd")+
+	  " "+RDCheckDateTime(startTime(),"hh:mm:ss")+"\")&&"+
+	  "(EVENT_DATETIME<\""+RDCheckDateTime(date,"yyyy-MM-dd")+" 23:59:59))||";
 	
       }
     }
@@ -534,9 +533,9 @@ bool RDReport::generateReport(const QDate &startdate,const QDate &enddate,
       // Daypart Filter
       //
       if(daypart_sql.isEmpty()) {
-	sql+=QString("(EVENT_DATETIME>=\"")+startdate.toString("yyyy-MM-dd")+
+	sql+=QString("(EVENT_DATETIME>=\"")+RDCheckDateTime(startdate,"yyyy-MM-dd")+
 	  " 00:00:00\")&&"+
-	  "(EVENT_DATETIME<=\""+enddate.toString("yyyy-MM-dd")+
+	  "(EVENT_DATETIME<=\""+RDCheckDateTime(enddate,"yyyy-MM-dd")+
 	  " 23:59:59\")&&";
       }
       else {
@@ -555,8 +554,8 @@ bool RDReport::generateReport(const QDate &startdate,const QDate &enddate,
 				   q1->value(1).toUInt(),
 				   q1->value(2).toInt())+
 	  "STATION_NAME=\""+RDEscapeString(q1->value(3).toString())+"\","+
-	  "EVENT_DATETIME=\""+RDEscapeString(q1->value(4).toDateTime().
-				     toString("yyyy-MM-dd hh:mm:ss"))+"\","+
+	  "EVENT_DATETIME=\""+RDCheckDateTime(q1->value(4).toDateTime(),
+				     "yyyy-MM-dd hh:mm:ss")+"\","+
 	  QString().sprintf("EVENT_TYPE=%d,",q1->value(5).toInt())+
 	  "EXT_START_TIME=\""+RDEscapeString(q1->value(6).toString())+"\","+
 	  QString().sprintf("EXT_LENGTH=%d,",q1->value(7).toInt())+
@@ -572,7 +571,7 @@ bool RDReport::generateReport(const QDate &startdate,const QDate &enddate,
 	  "TITLE=\""+RDEscapeString(q1->value(16).toString())+"\","+
 	  "ARTIST=\""+RDEscapeString(q1->value(17).toString())+"\","+
 	  "SCHEDULED_TIME=\""+
-	  q1->value(18).toDate().toString("yyyy-MM-dd hh:mm:ss")+"\","+
+	  RDCheckDateTime(q1->value(18).toDate(),"yyyy-MM-dd hh:mm:ss")+"\","+
 	  QString().sprintf("START_SOURCE=%d,",q1->value(19).toInt())+
 	  "PUBLISHER=\""+RDEscapeString(q1->value(20).toString())+"\","+
 	  "COMPOSER=\""+RDEscapeString(q1->value(21).toString())+"\","+
@@ -923,7 +922,7 @@ void RDReport::SetRow(const QString &param,const QTime &value) const
 
   sql=QString().sprintf("UPDATE REPORTS SET %s=\"%s\" WHERE NAME=\"%s\"",
 			(const char *)param,
-			(const char *)value.toString("hh:mm:ss"),
+			(const char *)RDCheckDateTime(value, "hh:mm:ss"),
 			(const char *)report_name);
   q=new RDSqlQuery(sql);
   delete q;

--- a/lib/rdreport.cpp
+++ b/lib/rdreport.cpp
@@ -346,20 +346,22 @@ bool RDReport::generateReport(const QDate &startdate,const QDate &enddate,
     for(int i=0;i<(startdate.daysTo(enddate)+1);i++) {
       QDate date=startdate.addDays(i);
       if(startTime()<endTime()) {
+    	  //TODO Do we need to escape on Select Statement?
 	daypart_sql+=QString("((EVENT_DATETIME>=\"")+
-	  RDCheckDateTime(date,"yyyy-MM-dd")+
-	  " "+RDCheckDateTime(startTime(),"hh:mm:ss")+"\")&&"+
-	  "(EVENT_DATETIME<\""+RDCheckDateTime(date,"yyyy-MM-dd")+
-	  " "+RDCheckDateTime(endTime(),"hh:mm:ss")+"\"))||";
+	  date.toString("yyyy-MM-dd")+
+	  " "+startTime().toString("hh:mm:ss")+"\")&&"+
+	  "(EVENT_DATETIME<\""+date.toString("yyyy-MM-dd")+
+	  " "+endTime().toString("hh:mm:ss")+"\"))||";
       }
       else {
 	daypart_sql+=QString("((EVENT_DATETIME<=\"")+
-	  RDCheckDateTime(date,"yyyy-MM-dd")+
-	  " "+RDCheckDateTime(endTime(),"hh:mm:ss")+"\")&&"+
-	  "(EVENT_DATETIME>\""+RDCheckDateTime(date,"yyyy-MM-dd")+" 00:00:00))||"+
-	  "((EVENT_DATETIME>=\""+RDCheckDateTime(date,"yyyy-MM-dd")+
-	  " "+RDCheckDateTime(startTime(),"hh:mm:ss")+"\")&&"+
-	  "(EVENT_DATETIME<\""+RDCheckDateTime(date,"yyyy-MM-dd")+" 23:59:59))||";
+	  date.toString("yyyy-MM-dd")+
+	  " "+endTime().toString("hh:mm:ss")+"\")&&"+
+	  "(EVENT_DATETIME>\""+date.toString("yyyy-MM-dd")+" 00:00:00))||"+
+	  "((EVENT_DATETIME>=\""+
+	  date.toString("yyyy-MM-dd")+
+	  " "+startTime().toString("hh:mm:ss")+"\")&&"+
+	  "(EVENT_DATETIME<\""+date.toString("yyyy-MM-dd")+" 23:59:59))||";
 	
       }
     }
@@ -533,9 +535,10 @@ bool RDReport::generateReport(const QDate &startdate,const QDate &enddate,
       // Daypart Filter
       //
       if(daypart_sql.isEmpty()) {
-	sql+=QString("(EVENT_DATETIME>=\"")+RDCheckDateTime(startdate,"yyyy-MM-dd")+
+    	  //TODO Do we need to escape on Select statement?
+	sql+=QString("(EVENT_DATETIME>=\"")+startdate.toString("yyyy-MM-dd")+
 	  " 00:00:00\")&&"+
-	  "(EVENT_DATETIME<=\""+RDCheckDateTime(enddate,"yyyy-MM-dd")+
+	  "(EVENT_DATETIME<=\""+enddate.toString("yyyy-MM-dd")+
 	  " 23:59:59\")&&";
       }
       else {

--- a/lib/rdreport.cpp
+++ b/lib/rdreport.cpp
@@ -557,8 +557,8 @@ bool RDReport::generateReport(const QDate &startdate,const QDate &enddate,
 				   q1->value(1).toUInt(),
 				   q1->value(2).toInt())+
 	  "STATION_NAME=\""+RDEscapeString(q1->value(3).toString())+"\","+
-	  "EVENT_DATETIME=\""+RDCheckDateTime(q1->value(4).toDateTime(),
-				     "yyyy-MM-dd hh:mm:ss")+"\","+
+	  "EVENT_DATETIME="+RDCheckDateTime(q1->value(4).toDateTime(),
+				     "yyyy-MM-dd hh:mm:ss")+","+
 	  QString().sprintf("EVENT_TYPE=%d,",q1->value(5).toInt())+
 	  "EXT_START_TIME=\""+RDEscapeString(q1->value(6).toString())+"\","+
 	  QString().sprintf("EXT_LENGTH=%d,",q1->value(7).toInt())+
@@ -573,8 +573,8 @@ bool RDReport::generateReport(const QDate &startdate,const QDate &enddate,
 	  "LOG_NAME=\""+RDEscapeString(q1->value(15).toString())+"\","+
 	  "TITLE=\""+RDEscapeString(q1->value(16).toString())+"\","+
 	  "ARTIST=\""+RDEscapeString(q1->value(17).toString())+"\","+
-	  "SCHEDULED_TIME=\""+
-	  RDCheckDateTime(q1->value(18).toDate(),"yyyy-MM-dd hh:mm:ss")+"\","+
+	  "SCHEDULED_TIME="+
+	  RDCheckDateTime(q1->value(18).toDate(),"yyyy-MM-dd hh:mm:ss")+","+
 	  QString().sprintf("START_SOURCE=%d,",q1->value(19).toInt())+
 	  "PUBLISHER=\""+RDEscapeString(q1->value(20).toString())+"\","+
 	  "COMPOSER=\""+RDEscapeString(q1->value(21).toString())+"\","+
@@ -923,7 +923,7 @@ void RDReport::SetRow(const QString &param,const QTime &value) const
   RDSqlQuery *q;
   QString sql;
 
-  sql=QString().sprintf("UPDATE REPORTS SET %s=\"%s\" WHERE NAME=\"%s\"",
+  sql=QString().sprintf("UPDATE REPORTS SET %s=%s WHERE NAME=\"%s\"",
 			(const char *)param,
 			(const char *)RDCheckDateTime(value, "hh:mm:ss"),
 			(const char *)report_name);

--- a/lib/rdsound_panel.cpp
+++ b/lib/rdsound_panel.cpp
@@ -1485,13 +1485,19 @@ void RDSoundPanel::LogTraffic(RDPanelButton *button)
     "CUTS.CUT_NAME=\""+RDEscapeString(button->cutName())+"\"";
   q=new RDSqlQuery(sql);
   if(q->first()) {
+
+    QString eventDateTimeSQL = "NULL";
+
+    if(dateTime.isValid() && button->startTime().isValid())
+      eventDateTimeSQL = RDCheckDateTime(QDateTime(dateTime.date(),
+            button->startTime()), "yyyy-MM-dd hh:mm:ss");
+
     sql=QString("insert into `")+panel_svcname+"_SRT` set "+
       QString().sprintf("LENGTH=%d,",button->startTime().
 			msecsTo(datetime.time()))+
       QString().sprintf("CART_NUMBER=%u,",button->cart())+
       "STATION_NAME=\""+RDEscapeString(panel_station->name().utf8())+"\","+
-      "EVENT_DATETIME=\""+datetime.toString("yyyy-MM-dd")+" "+
-      RDCheckDateTime(button->startTime(),"hh:mm:ss")+"\","+
+      "EVENT_DATETIME="+eventDateTimeSQL+","+
       QString().sprintf("EVENT_TYPE=%d,",RDAirPlayConf::TrafficStop)+
       QString().sprintf("EVENT_SOURCE=%d,",RDLogLine::SoundPanel)+
       QString().sprintf("PLAY_SOURCE=%d,",RDLogLine::SoundPanel)+

--- a/lib/rdsound_panel.cpp
+++ b/lib/rdsound_panel.cpp
@@ -1488,8 +1488,8 @@ void RDSoundPanel::LogTraffic(RDPanelButton *button)
 
     QString eventDateTimeSQL = "NULL";
 
-    if(dateTime.isValid() && button->startTime().isValid())
-      eventDateTimeSQL = RDCheckDateTime(QDateTime(dateTime.date(),
+    if(datetime.isValid() && button->startTime().isValid())
+      eventDateTimeSQL = RDCheckDateTime(QDateTime(datetime.date(),
             button->startTime()), "yyyy-MM-dd hh:mm:ss");
 
     sql=QString("insert into `")+panel_svcname+"_SRT` set "+

--- a/lib/rdsound_panel.cpp
+++ b/lib/rdsound_panel.cpp
@@ -1491,7 +1491,7 @@ void RDSoundPanel::LogTraffic(RDPanelButton *button)
       QString().sprintf("CART_NUMBER=%u,",button->cart())+
       "STATION_NAME=\""+RDEscapeString(panel_station->name().utf8())+"\","+
       "EVENT_DATETIME=\""+datetime.toString("yyyy-MM-dd")+" "+
-      button->startTime().toString("hh:mm:ss")+"\","+
+      RDCheckDateTime(button->startTime(),"hh:mm:ss")+"\","+
       QString().sprintf("EVENT_TYPE=%d,",RDAirPlayConf::TrafficStop)+
       QString().sprintf("EVENT_SOURCE=%d,",RDLogLine::SoundPanel)+
       QString().sprintf("PLAY_SOURCE=%d,",RDLogLine::SoundPanel)+

--- a/lib/rdsvc.cpp
+++ b/lib/rdsvc.cpp
@@ -754,9 +754,9 @@ bool RDSvc::generateLog(const QDate &date,const QString &logname,
   //
   // Generate Log Structure
   //
-  QString purge_date;
+  QDate purge_date;
   if(defaultLogShelflife()>=0) {
-    purge_date=date.addDays(defaultLogShelflife()).toString("yyyy-MM-dd");
+    purge_date=date.addDays(defaultLogShelflife());
   }
   sql=QString().sprintf("select NAME from LOGS where NAME=\"%s\"",
 			(const char *)RDEscapeString(logname));
@@ -771,8 +771,8 @@ bool RDSvc::generateLog(const QDate &date,const QString &logname,
 			  (const char *)RDEscapeString(svc_name),
 			  (const char *)RDEscapeString(RDDateDecode(descriptionTemplate(),date)),
 			  "RDLogManager");
-    if(!purge_date.isEmpty()) {
-      sql+=(",PURGE_DATE=\""+purge_date+"\"");
+    if(!purge_date.isValid()) {
+      sql+=(",PURGE_DATE=\""+purge_date.toString("yyyy-MM-dd")+"\"");
     }
     sql+=(" where NAME=\""+RDEscapeString(logname)+"\"");
 
@@ -793,7 +793,7 @@ bool RDSvc::generateLog(const QDate &date,const QString &logname,
 			  (const char *)RDEscapeString(svc_name),
 			  (const char *)RDEscapeString(RDDateDecode(descriptionTemplate(),date)),
 			  "RDLogManager",
-			  (const char *)purge_date);
+			  (const char *)RDCheckDateTime(purge_date,"yyyy-MM-dd"));
     q=new RDSqlQuery(sql);
     delete q;
   }

--- a/lib/rdsvc.cpp
+++ b/lib/rdsvc.cpp
@@ -788,7 +788,7 @@ bool RDSvc::generateLog(const QDate &date,const QString &logname,
                            SERVICE=\"%s\",DESCRIPTION=\"%s\",\
                            ORIGIN_USER=\"%s\",ORIGIN_DATETIME=now(),\
                            LINK_DATETIME=now(),MODIFIED_DATETIME=now(),\
-                           PURGE_DATE=\"%s\"",
+                           PURGE_DATE=%s",
 			  (const char *)RDEscapeString(logname),
 			  (const char *)RDEscapeString(svc_name),
 			  (const char *)RDEscapeString(RDDateDecode(descriptionTemplate(),date)),

--- a/rdairplay/log_traffic.cpp
+++ b/rdairplay/log_traffic.cpp
@@ -51,10 +51,10 @@ void LogTraffic(const QString &svcname,const QString &logname,
     QString().sprintf("CART_NUMBER=%u,",logline->cartNumber())+
     "STATION_NAME=\""+RDEscapeString(rdstation_conf->name().utf8())+"\","+
     "EVENT_DATETIME=\""+datetime.toString("yyyy-MM-dd")+" "+
-    logline->startTime(RDLogLine::Actual).toString("hh:mm:ss")+"\","+
+    RDCheckDateTime(logline->startTime(RDLogLine::Actual),"hh:mm:ss")+"\","+
     QString().sprintf("EVENT_TYPE=%d,",action)+
     QString().sprintf("EVENT_SOURCE=%d,",logline->source())+
-    "EXT_START_TIME=\""+logline->extStartTime().toString("hh:mm:ss")+"\","+
+    "EXT_START_TIME=\""+RDCheckDateTime(logline->extStartTime(),"hh:mm:ss")+"\","+
     QString().sprintf("EXT_LENGTH=%d,",logline->extLength())+
     "EXT_DATA=\""+RDEscapeString(logline->extData())+"\","+
     "EXT_EVENT_ID=\""+RDEscapeString(logline->extEventId())+"\","+
@@ -64,8 +64,8 @@ void LogTraffic(const QString &svcname,const QString &logname,
     "EXT_CART_NAME=\""+RDEscapeString(logline->extCartName().utf8())+"\","+
     "TITLE=\""+RDEscapeString(logline->title().utf8())+"\","+
     "ARTIST=\""+RDEscapeString(logline->artist().utf8())+"\","+
-    "SCHEDULED_TIME=\""+RDEscapeString(logline->startTime(RDLogLine::Logged).
-				       toString("hh:mm:ss"))+"\","+
+    "SCHEDULED_TIME=\""+RDCheckDateTime(logline->startTime(RDLogLine::Logged),
+				       "hh:mm:ss")+"\","+
     "ISRC=\""+RDEscapeString(logline->isrc().utf8())+"\","+
     "PUBLISHER=\""+RDEscapeString(logline->publisher().utf8())+"\","+
     "COMPOSER=\""+RDEscapeString(logline->composer().utf8())+"\","+

--- a/rdairplay/log_traffic.cpp
+++ b/rdairplay/log_traffic.cpp
@@ -44,14 +44,20 @@ void LogTraffic(const QString &svcname,const QString &logname,
   if((logline==NULL)||(svcname.isEmpty())) {
     return;
   }
+
+  QString eventDateTimeSQL = "NULL";
+
+  if(datetime.isValid() && logline->startTime(RDLogLine::Actual).isValid())
+    eventDateTimeSQL = RDCheckDateTime(QDateTime(datetime.date(),
+          logline->startTime(RDLogLine::Actual)), "yyyy-MM-dd hh:mm:ss");
+
   sql=QString("insert into `")+RDSvc::svcTableName(svcname)+"` set "+
     QString().sprintf("LENGTH=%d,",length)+
     "LOG_NAME=\""+RDEscapeString(logname.utf8())+"\","+
     QString().sprintf("LOG_ID=%d,",logline->id())+
     QString().sprintf("CART_NUMBER=%u,",logline->cartNumber())+
     "STATION_NAME=\""+RDEscapeString(rdstation_conf->name().utf8())+"\","+
-    "EVENT_DATETIME=\""+datetime.toString("yyyy-MM-dd")+" "+
-    RDCheckDateTime(logline->startTime(RDLogLine::Actual),"hh:mm:ss")+"\","+
+    "EVENT_DATETIME="+eventDateTimeSQL+","+
     QString().sprintf("EVENT_TYPE=%d,",action)+
     QString().sprintf("EVENT_SOURCE=%d,",logline->source())+
     "EXT_START_TIME=\""+RDCheckDateTime(logline->extStartTime(),"hh:mm:ss")+"\","+
@@ -64,8 +70,8 @@ void LogTraffic(const QString &svcname,const QString &logname,
     "EXT_CART_NAME=\""+RDEscapeString(logline->extCartName().utf8())+"\","+
     "TITLE=\""+RDEscapeString(logline->title().utf8())+"\","+
     "ARTIST=\""+RDEscapeString(logline->artist().utf8())+"\","+
-    "SCHEDULED_TIME=\""+RDCheckDateTime(logline->startTime(RDLogLine::Logged),
-				       "hh:mm:ss")+"\","+
+    "SCHEDULED_TIME="+RDCheckDateTime(logline->startTime(RDLogLine::Logged),
+				       "hh:mm:ss")+","+
     "ISRC=\""+RDEscapeString(logline->isrc().utf8())+"\","+
     "PUBLISHER=\""+RDEscapeString(logline->publisher().utf8())+"\","+
     "COMPOSER=\""+RDEscapeString(logline->composer().utf8())+"\","+

--- a/rdcatchd/rdcatchd.cpp
+++ b/rdcatchd/rdcatchd.cpp
@@ -2609,7 +2609,7 @@ void MainObject::ResolveErrorWildcards(CatchEvent *event,
   rml->replace("%d",event->description());
   rml->replace("%e",err_desc);  // Error Description
   rml->replace("%i",QString().sprintf("%u",event->id()));
-  rml->replace("%t",RDCheckDateTime(event->startTime(),"hh:mm:ss"));
+  rml->replace("%t",event->startTime().toString("hh:mm:ss"));
   rml->replace("%y",RDRecording::typeString(event->type()));
   switch(event->type()) {
       case RDRecording::Recording:

--- a/rdcatchd/rdcatchd.cpp
+++ b/rdcatchd/rdcatchd.cpp
@@ -2609,7 +2609,7 @@ void MainObject::ResolveErrorWildcards(CatchEvent *event,
   rml->replace("%d",event->description());
   rml->replace("%e",err_desc);  // Error Description
   rml->replace("%i",QString().sprintf("%u",event->id()));
-  rml->replace("%t",event->startTime().toString("hh:mm:ss"));
+  rml->replace("%t",RDCheckDateTime(event->startTime(),"hh:mm:ss"));
   rml->replace("%y",RDRecording::typeString(event->type()));
   switch(event->type()) {
       case RDRecording::Recording:

--- a/tests/sas_switch_torture.cpp
+++ b/tests/sas_switch_torture.cpp
@@ -29,6 +29,7 @@
 #include <rd.h>
 #include <rddb.h>
 #include <sas_switch_torture.h>
+#include <rdescape_string.h>
 
 MainWidget::MainWidget(QWidget *parent)
   :QWidget(parent)
@@ -123,7 +124,7 @@ void MainWidget::generateData()
                          SUN=\'Y\',MON=\'Y\',TUE=\'Y\',WED=\'Y\',THU=\'Y\',\
                          FRI=\'Y\',SAT=\'Y\',DESCRIPTION=\"%s\",\
                          CUT_NAME=\"SAS_SWITCH_TORTURE\",\
-                         START_TIME=\"%s\",TYPE=1",
+                         START_TIME=%s,TYPE=1",
 			      SAS_STATION,
 			      SAS_MATRIX,
 			      j+1,

--- a/tests/sas_switch_torture.cpp
+++ b/tests/sas_switch_torture.cpp
@@ -129,7 +129,7 @@ void MainWidget::generateData()
 			      j+1,
 			      k+1,
 			      (const char *)desc,
-			      (const char *)time.toString("hh:mm:ss"));
+			      (const char *)RDCheckDateTime(time,"hh:mm:ss"));
 	q=new RDSqlQuery(sql);
 	delete q;
       }

--- a/tests/sas_torture.cpp
+++ b/tests/sas_torture.cpp
@@ -29,6 +29,7 @@
 #include <rd.h>
 #include <rddb.h>
 #include <sas_torture.h>
+#include <rdescape_string.h>
 
 MainWidget::MainWidget(QWidget *parent)
   :QWidget(parent)
@@ -137,7 +138,7 @@ void MainWidget::generateData()
                          SUN=\'Y\',MON=\'Y\',TUE=\'Y\',WED=\'Y\',THU=\'Y\',\
                          FRI=\'Y\',SAT=\'Y\',DESCRIPTION=\"%s\",\
                          CUT_NAME=\"SAS_TORTURE\",MACRO_CART=%d,\
-                         START_TIME=\"%s\",TYPE=1",
+                         START_TIME=%s,TYPE=1",
 			    SAS_STATION,
 			    (const char *)desc,
 			    CART_START+j,

--- a/tests/sas_torture.cpp
+++ b/tests/sas_torture.cpp
@@ -141,7 +141,7 @@ void MainWidget::generateData()
 			    SAS_STATION,
 			    (const char *)desc,
 			    CART_START+j,
-			    (const char *)time.toString("hh:mm:ss"));
+			    (const char *)RDCheckDateTime(time,"hh:mm:ss"));
       q=new RDSqlQuery(sql);
       delete q;
     }

--- a/utils/rddgimport/rddgimport.cpp
+++ b/utils/rddgimport/rddgimport.cpp
@@ -431,6 +431,12 @@ bool MainWidget::CheckSpot(const QString &isci)
   QDate today=QDate::currentDate();
   QDate killdate=dg_date_edit->date().addDays(RDDGIMPORT_KILLDATE_OFFSET);
 
+  QString endDateTimeSQL = "NULL";
+
+  if(killdate.isValid())
+    endDateTimeSQL = RDCheckDateTime(QDateTime(killdate,QTime(23,59,59)),
+                                    "yyyy-MM-dd hh:mm:ss");
+
   sql=QString("select CUT_NAME,CUTS.START_DATETIME,CUTS.END_DATETIME ")+
     "from CART left join CUTS on CART.NUMBER=CUTS.CART_NUMBER "+
     "where (CART.GROUP_NAME=\""+RDEscapeString(dg_svc->autospotGroup())+"\")&&"
@@ -443,7 +449,7 @@ bool MainWidget::CheckSpot(const QString &isci)
       if(q->value(1).isNull()) {
 	sql+="START_DATETIME=\""+today.toString("yyyy-MM-dd")+" 00:00:00\",";
       }
-      sql+="END_DATETIME=\""+RDCheckDateTime(killdate,"yyyy-MM-dd")+" 23:59:59\" ";
+      sql+="END_DATETIME="+endDateTimeSQL+" ";
       sql+="where CUT_NAME=\""+q->value(0).toString()+"\"";
       q1=new RDSqlQuery(sql);
       delete q1;

--- a/utils/rddgimport/rddgimport.cpp
+++ b/utils/rddgimport/rddgimport.cpp
@@ -443,7 +443,7 @@ bool MainWidget::CheckSpot(const QString &isci)
       if(q->value(1).isNull()) {
 	sql+="START_DATETIME=\""+today.toString("yyyy-MM-dd")+" 00:00:00\",";
       }
-      sql+="END_DATETIME=\""+killdate.toString("yyyy-MM-dd")+" 23:59:59\" ";
+      sql+="END_DATETIME=\""+RDCheckDateTime(killdate,"yyyy-MM-dd")+" 23:59:59\" ";
       sql+="where CUT_NAME=\""+q->value(0).toString()+"\"";
       q1=new RDSqlQuery(sql);
       delete q1;

--- a/utils/rdimport/rdimport.cpp
+++ b/utils/rdimport/rdimport.cpp
@@ -1864,13 +1864,13 @@ void MainObject::WriteTimestampCache(const QString &filename,
     sql=QString().sprintf("insert into DROPBOX_PATHS set \
                            DROPBOX_ID=%d,\
                            FILE_PATH=\"%s\",\
-                           FILE_DATETIME=\"%s\"",
+                           FILE_DATETIME=%s",
 			  import_persistent_dropbox_id,
 			  (const char *)RDEscapeString(filename),
 			  (const char *)RDCheckDateTime(dt,"yyyy-MM-dd hh:mm:ss"));
   }
   else {
-    sql=QString().sprintf("update DROPBOX_PATHS set FILE_DATETIME=\"%s\" \
+    sql=QString().sprintf("update DROPBOX_PATHS set FILE_DATETIME=%s \
                            where (DROPBOX_ID=%d)&&(FILE_PATH=\"%s\")",
 			  (const char *)RDCheckDateTime(dt,"yyyy-MM-dd hh:mm:ss"),
 			  import_persistent_dropbox_id,

--- a/utils/rdimport/rdimport.cpp
+++ b/utils/rdimport/rdimport.cpp
@@ -1867,12 +1867,12 @@ void MainObject::WriteTimestampCache(const QString &filename,
                            FILE_DATETIME=\"%s\"",
 			  import_persistent_dropbox_id,
 			  (const char *)RDEscapeString(filename),
-			  (const char *)dt.toString("yyyy-MM-dd hh:mm:ss"));
+			  (const char *)RDCheckDateTime(dt,"yyyy-MM-dd hh:mm:ss"));
   }
   else {
     sql=QString().sprintf("update DROPBOX_PATHS set FILE_DATETIME=\"%s\" \
                            where (DROPBOX_ID=%d)&&(FILE_PATH=\"%s\")",
-			  (const char *)dt.toString("yyyy-MM-dd hh:mm:ss"),
+			  (const char *)RDCheckDateTime(dt,"yyyy-MM-dd hh:mm:ss"),
 			  import_persistent_dropbox_id,
 			  (const char *)RDEscapeString(filename));
   }

--- a/web/rdcastmanager/rdcastmanager.cpp
+++ b/web/rdcastmanager/rdcastmanager.cpp
@@ -1322,8 +1322,8 @@ void MainObject::CommitCast()
 			(const char *)RDEscapeString(item_source_text),
 			(const char *)RDEscapeString(item_source_url),
 			shelf_life,
-			(const char *)RDLocalToUtc(effective_datetime).
-			toString("yyyy-MM-dd hh:mm:ss"),
+			(const char *)RDCheckDateTime(RDLocalToUtc(effective_datetime),
+			    "yyyy-MM-dd hh:mm:ss"),
 			cast_cast_id);
   q=new RDSqlQuery(sql);
   delete q;

--- a/web/rdcastmanager/rdcastmanager.cpp
+++ b/web/rdcastmanager/rdcastmanager.cpp
@@ -1310,7 +1310,7 @@ void MainObject::CommitCast()
                          ITEM_SOURCE_TEXT=\"%s\",\
                          ITEM_SOURCE_URL=\"%s\",\
                          SHELF_LIFE=%d,\
-                         EFFECTIVE_DATETIME=\"%s\" \
+                         EFFECTIVE_DATETIME=%s \
                          where ID=%d",
 			status,
 			(const char *)RDEscapeString(item_title),


### PR DESCRIPTION
Pull request to resolve #121 date/time changes in MySQL v5.7+ for record insertion/updates.

I've done a lot of searching across the entirety of the Riv codebase for references to dates and times either as variable types or that reference database fields that are DATETIME (and variants).  I have the full 1,500 line matches file and the smaller 250 ish line file that I narrowed down after checking line by line.

I added a bunch of RDCheckDateTime methods to rdescape_string.cpp.  Most of the fixes revolve around finding where the original date/time/datetime is used and wrapping an isValid check around it that either returns a QString of the formatted date/time or "NULL" (not NULL a QString that says "NULL").

There is potential for some of the SELECT statements to suffer the same faults but the ones I've looked at would return weird results in both versions so I think it should be fine left as is.

For example what should happen if you have this kind of SQL:

select * from LOGS where START_DATE >= QDateVariable + " 23:59:59"

That might evaluate down as a "" for the QDate and then here be dragons (START_DATE >= " 23:59:59").

Please note, there are a bunch of random bugs I found on my travels in the 2.13.0 code mentioned in #121.  This pull request is nothing to do with those.  I will deal with those separately once/if I find them on the stable branch.