### PR TITLE
Delete event dialog displays wrong identifier

### DIFF
--- a/lib/rdevent_line.cpp
+++ b/lib/rdevent_line.cpp
@@ -630,9 +630,9 @@ bool RDEventLine::generateLog(QString logname,const QString &svcname,
       }
       delete q;
       
-      sql=QString().sprintf("SELECT SCHED_STACK_ID from %s_STACK order by SCHED_STACK_ID",(const char*)svcname_rp);
+      sql=QString().sprintf("SELECT MAX(SCHED_STACK_ID) from %s_STACK",(const char*)svcname_rp);
       q=new RDSqlQuery(sql);
-      if (q->last())
+      if (q->next())
       { 
 	stackid=q->value(0).toUInt();
       }
@@ -833,11 +833,13 @@ bool RDEventLine::generateLog(QString logname,const QString &svcname,
 
       count++;
 
+      time_type=RDLogLine::Relative;
 
 
-      sql=QString().sprintf("insert into `%s_STACK` set SCHED_STACK_ID=%u,CART=%u,ARTIST=\"%s\",SCHED_CODES=\"%s\"",(const char*)svcname_rp,
+      sql=QString().sprintf("insert into `%s_STACK` set SCHED_STACK_ID=%u,CART=%u,ARTIST=\"%s\",SCHED_CODES=\"%s\",SCHEDULED_AT=\"%s\"",(const char*)svcname_rp,
 			    stackid,schedCL->getItemCartnumber(schedpos),
-			    (const char *)RDEscapeString(schedCL->getItemArtist(schedpos)),(const char *)schedCL->getItemSchedCodes(schedpos));
+			    (const char *)RDEscapeString(schedCL->getItemArtist(schedpos)),(const char *)schedCL->getItemSchedCodes(schedpos),
+			    (const char *)QDateTime(QDate::currentDate(),QTime::currentTime()).toString("yyyy-MM-dd hh:mm:ss"));
       q=new RDSqlQuery(sql);
       delete q;
       delete schedCL;

--- a/rdlogmanager/edit_clock.cpp
+++ b/rdlogmanager/edit_clock.cpp
@@ -377,10 +377,12 @@ void EditClock::deleteData()
   if(item->text(4).isEmpty()) {
     return;
   }
-  str=QString(tr("Are you sure you want to\ndelete"));
+  str=QString(tr("Are you sure you want to delete\n"));
   if(QMessageBox::question(this,tr("Delete Event"),
-			   QString().sprintf("%s \'%s\'?",(const char *)str,
-			 (const char *)item->text(3)),
+			   QString().sprintf("%s \'(%s-%s) %s\'?",(const char *)str,
+			 (const char *)item->text(0),
+			 (const char *)item->text(1),
+			 (const char *)item->text(2)),
 			  QMessageBox::Yes,QMessageBox::No)!=
      QMessageBox::Yes) {
     return;


### PR DESCRIPTION
Found bug were delete event dialog displayed event length
rather than proper identifier. Dialog now displays start time,
end time, and description of event.