### PR TITLE
Validate position within string we're being asked to validate

### DIFF
--- a/lib/rdtextvalidator.cpp
+++ b/lib/rdtextvalidator.cpp
@@ -38,7 +38,7 @@ QValidator::State RDTextValidator::validate(QString &input,int &pos) const
     return QValidator::Acceptable;
   }
   int inspectionPos = std::max(0,std::min(input.length()-1,pos));
-  char c=input.at(pos-1).latin1();
+  char c=input.at(inspectionPos).latin1();
   for(unsigned i=0;i<banned_chars.size();i++) {
     if(banned_chars[i]==c) {
       return QValidator::Invalid;

--- a/lib/rdtextvalidator.cpp
+++ b/lib/rdtextvalidator.cpp
@@ -37,8 +37,8 @@ QValidator::State RDTextValidator::validate(QString &input,int &pos) const
   if (input.length()==0) {
     return QValidator::Acceptable;
   }
-  int inspectionPos = std::max(0,std::min(input.length()-1,pos));
-  char c=input.at(inspectionPos).latin1();
+  int inspection_pos = std::max(0,std::min(input.length()-1,pos));
+  char c=input.at(inspection_pos).latin1();
   for(unsigned i=0;i<banned_chars.size();i++) {
     if(banned_chars[i]==c) {
       return QValidator::Invalid;

--- a/lib/rdtextvalidator.cpp
+++ b/lib/rdtextvalidator.cpp
@@ -34,6 +34,10 @@ RDTextValidator::RDTextValidator(QObject *parent,const char *name,bool allow_quo
 
 QValidator::State RDTextValidator::validate(QString &input,int &pos) const
 {
+  if (input.length()==0) {
+    return QValidator::Acceptable;
+  }
+  int inspectionPos = std::max(0,std::min(input.length()-1,pos));
   char c=input.at(pos-1).latin1();
   for(unsigned i=0;i<banned_chars.size();i++) {
     if(banned_chars[i]==c) {


### PR DESCRIPTION
Previously, pressing backspace with a 1-character string blew up because pos=0, so pos-1=-1,
and strings of length zero always segfaulted because there are no characters to inspect.

Fixes #152 on Ubuntu 16.04 / Qt4.