### PR TITLE
Patches for building on Ubuntu 18.04

### DIFF
--- a/cae/cae_alsa.cpp
+++ b/cae/cae_alsa.cpp
@@ -1140,7 +1140,7 @@ bool MainObject::alsaSetInputVolume(int card,int stream,int level)
 {
 #ifdef ALSA
   if(level>-10000) {
-    alsa_input_volume[card][stream]=pow10((double)level/2000.0);
+    alsa_input_volume[card][stream]=pow(10.0,(double)level/2000.0);
     alsa_input_volume_db[card][stream]=level;
   }
   else {
@@ -1158,7 +1158,7 @@ bool MainObject::alsaSetOutputVolume(int card,int stream,int port,int level)
 {
 #ifdef ALSA
   if(level>-10000) {
-    alsa_output_volume[card][port][stream]=pow10((double)level/2000.0);
+    alsa_output_volume[card][port][stream]=pow(10.0,(double)level/2000.0);
     alsa_output_volume_db[card][port][stream]=level;
   }
   else {
@@ -1366,7 +1366,7 @@ bool MainObject::alsaSetPassthroughLevel(int card,int in_port,int out_port,
 #ifdef ALSA
   if(level>-10000) {
     alsa_passthrough_volume[card][in_port][out_port]=
-      pow10((double)level/2000.0);
+      pow(10.0,(double)level/2000.0);
     alsa_passthrough_volume_db[card][in_port][out_port]=level;
   }
   else {

--- a/cae/cae_jack.cpp
+++ b/cae/cae_jack.cpp
@@ -1071,7 +1071,7 @@ bool MainObject::jackSetInputVolume(int card,int stream,int level)
   }
   if(level>-10000) {
     jack_input_volume[stream]=
-      (jack_default_audio_sample_t)pow10((double)level/2000.0);
+      (jack_default_audio_sample_t)pow(10.0,(double)level/2000.0);
     jack_input_volume_db[stream]=level;
   }
   else {
@@ -1094,7 +1094,7 @@ bool MainObject::jackSetOutputVolume(int card,int stream,int port,int level)
   }
   if(level>-10000) {
     jack_output_volume[port][stream]=
-      (jack_default_audio_sample_t)pow10((double)level/2000.0);
+      (jack_default_audio_sample_t)pow(10.0,(double)level/2000.0);
     jack_output_volume_db[port][stream]=level;
   }
   else {
@@ -1315,7 +1315,7 @@ bool MainObject::jackSetPassthroughLevel(int card,int in_port,int out_port,
   }
   if(level>-10000) {
     jack_passthrough_volume[in_port][out_port]=
-      (jack_default_audio_sample_t)pow10((double)level/2000.0);
+      (jack_default_audio_sample_t)pow(10.0,(double)level/2000.0);
     jack_passthrough_volume_db[in_port][out_port]=level;
   }
   else {


### PR DESCRIPTION
There are several more bugs I don't really know the answer for.
Most are I suspect related to MySQL 5.7 security.
To setup the initial database, rdadmin must be run as root.

Then there are about a half dozen mysql errors while running the various rivendell applications, rdadmin, rdcatch, rdlogedit, rdlogmanager, rdpanel:

rdadmin
invalid SQL or failed DB connection[Field 'INSTANCE' doesn't have a default value QMYSQL3: Unable to execute query]: insert into RDPANEL set STATION="Rivendell-VirtualBox"

Database connection failed: insert into RDPANEL set STATION="Rivendell-VirtualBox"
QSqlQuery::value: not positioned on a valid record

invalid SQL or failed DB connection[Field 'PORT_2' doesn't have a default value QMYSQL3: Unable to execute query]: insert into MATRICES set STATION_NAME="Rivendell-VirtualBox",NAME="New Switcher",GPIO_DEVICE="/dev/gpio0",MATRIX=0, PORT=0, TYPE=15, INPUTS=0, OUTPUTS=0, GPIS=0, GPOS=0, PORT_TYPE=0, PORT_TYPE_2=2

invalid SQL or failed DB connection[Field 'TYPE_ID' doesn't have a default value QMYSQL3: Unable to execute query]: insert into REPLICATORS set NAME="Test"

rdcatch
invalid SQL or failed DB connection[Field 'STATION_NAME' doesn't have a default value QMYSQL3: Unable to execute query]: insert into RECORDINGS set ID=1
Database connection failed: insert into RECORDINGS set ID=1
Segmentation fault (core dumped)

rdlogedit
invalid SQL or failed DB connection[Field 'MODIFIED_DATETIME' doesn't have a default value QMYSQL3: Unable to execute query]: insert into LOGS set NAME="MyTest",TYPE=0,DESCRIPTION="MyTest log ",ORIGIN_USER="user",ORIGIN_DATETIME=now(),LINK_DATETIME=now(),SERVICE="Production"
Database connection failed: insert into LOGS set NAME="MyTest",TYPE=0,DESCRIPTION="MyTest log",ORIGIN_USER="user",ORIGIN_DATETIME=now(),LINK_DATETIME=now(),SERVICE="Production"

rdlogmanager
Grabbing the mouse failed with "GrabInvalidTime"
invalid SQL or failed DB connection[Field 'MODIFIED_DATETIME' doesn't have a default value QMYSQL3: Unable to execute query]: insert into LOGS set NAME="Production-0425",TYPE=0,DESCRIPTION="Production-0425 log ",ORIGIN_USER="RDLogManager",ORIGIN_DATETIME=now(),LINK_DATETIME=now(),SERVICE="Production"
Database connection failed: insert into LOGS set NAME="Production-0425",TYPE=0,DESCRIPTION="Production-0425 log ",ORIGIN_USER="RDLogManager",ORIGIN_DATETIME=now(),LINK_DATETIME=now(),SERVICE="Production"

rdpanel
invalid SQL or failed DB connection[Field 'INSTANCE' doesn't have a default value QMYSQL3: Unable to execute query]: insert into RDPANEL set STATION="Kubuntu-VirtualBox"
Database connection failed: insert into RDPANEL set STATION="Kubuntu-VirtualBox"
QSqlQuery::value: not positioned on a valid record
Segmentation fault (core dumped)

rdselect
Segmentation fault (core dumped)