### PR TITLE
Purge STACK tables in RDMaint

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -16965,3 +16965,6 @@
 	the STACK".
 2018-05-30 Fred Gleason <fredg@paravelsystems.com>
 	* Implemented '%v/%V' metadata wildcards for event length (seconds).
+2018-05-30 Patrick Linstruth <patrick@deltecent.com>
+	* Implemented purging of STACK_* tables for RDMaint(1) in
+        'utils/rdmaint/rdmaint.cpp' and 'utils/rdmaint/rdmaint.h'.

--- a/utils/rdmaint/rdmaint.cpp
+++ b/utils/rdmaint/rdmaint.cpp
@@ -329,7 +329,7 @@ void MainObject::PurgeStacks()
         q2=new RDSqlQuery(sql);
         delete q2;
 
-        sql=QString().sprintf("UPDATE `%s` SET SCHED_STACK_ID=SCHED_STACK_ID-%d", (const char*)tablename, stacksize-1);
+        sql=QString().sprintf("UPDATE `%s` SET SCHED_STACK_ID=SCHED_STACK_ID-%d", (const char*)tablename, stackid-stacksize);
         q2=new RDSqlQuery(sql);
         delete q2;
       }

--- a/utils/rdmaint/rdmaint.cpp
+++ b/utils/rdmaint/rdmaint.cpp
@@ -127,6 +127,7 @@ void MainObject::RunSystemMaintenance()
   PurgeElr();
   PurgeGpioEvents();
   PurgeWebapiAuths();
+  PurgeStacks();
   RehashCuts();
 }
 
@@ -282,6 +283,59 @@ void MainObject::PurgeWebapiAuths()
 
   sql=QString("delete from WEBAPI_AUTHS where EXPIRATION_DATETIME<now()");
   q=new RDSqlQuery(sql);
+  delete q;
+}
+
+
+void MainObject::PurgeStacks()
+{
+  QString sql;
+  RDSqlQuery *q;
+  RDSqlQuery *q1;
+  RDSqlQuery *q2;
+  int stackid;
+  int stacksize;
+  int artistsep=50000;
+  int titlesep=50000;
+
+  sql="select MAX(ARTISTSEP) from CLOCKS";
+  q=new RDSqlQuery(sql);
+  if(q->next()) {
+    artistsep=q->value(0).toInt();
+  }
+  delete q;
+
+  sql="select MAX(TITLE_SEP) from EVENTS";
+  q=new RDSqlQuery(sql);
+  if(q->next()) {
+    titlesep=q->value(0).toInt();
+  }
+  delete q;
+
+  stacksize=(artistsep<titlesep)?titlesep:artistsep;
+
+  sql="select NAME from SERVICES";
+  q=new RDSqlQuery(sql);
+  while(q->next()) {
+    QString tablename=q->value(0).toString()+"_STACK";
+    tablename.replace(" ","_");
+    sql=QString().sprintf("SELECT MAX(SCHED_STACK_ID) from %s",(const char*)tablename);
+    q1=new RDSqlQuery(sql);
+    if (q1->next())
+    { 
+      stackid=q1->value(0).toUInt();
+      if (stackid-stacksize > 0) {
+        sql=QString().sprintf("DELETE from `%s` where SCHED_STACK_ID <= %d", (const char*)tablename, stackid-stacksize);
+        q2=new RDSqlQuery(sql);
+        delete q2;
+
+        sql=QString().sprintf("UPDATE `%s` SET SCHED_STACK_ID=SCHED_STACK_ID-%d", (const char*)tablename, stacksize-1);
+        q2=new RDSqlQuery(sql);
+        delete q2;
+      }
+    }
+    delete q1;
+  }
   delete q;
 }
 

--- a/utils/rdmaint/rdmaint.h
+++ b/utils/rdmaint/rdmaint.h
@@ -39,6 +39,7 @@ class MainObject : public QObject
   void PurgeDropboxes();
   void PurgeGpioEvents();
   void PurgeWebapiAuths();
+  void PurgeStacks();
   void RehashCuts();
   bool maint_verbose;
   bool maint_system;


### PR DESCRIPTION
The STACK only needs to reference as far back as needed to implement artist and title separation. This pull request looks at the artist and title separations to determine the number of carts to keep on the stack. The other carts are removed and the stack is renumbered.