### PR TITLE
Initial play/stop buttons for Rdlibrary

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -17010,3 +17010,5 @@
 	* Incremented the package version to 2.19.2vlog03.
 2018-05-31 Fred Gleason <fredg@paravelsystems.com>
 	* Fixed a bug that broke the build on RHEL 6.
+2018-06-03 Patrick Linstruth <patrick@deltecent.com>
+	* Implemented initial play/stop buttons in RDLibrary(1)

--- a/rdlibrary/rdlibrary.cpp
+++ b/rdlibrary/rdlibrary.cpp
@@ -1,4 +1,4 @@
-//
+// rdlibrary.cpp
 //
 // The Library Utility for Rivendell.
 //

--- a/rdlibrary/rdlibrary.h
+++ b/rdlibrary/rdlibrary.h
@@ -26,6 +26,7 @@
 #include <qsizepolicy.h>
 #include <qsqldatabase.h>
 #include <rdlistview.h>
+#include <rdsimpleplayer.h>
 #include <qpushbutton.h>
 #include <qcombobox.h>
 #include <qlabel.h>
@@ -130,6 +131,9 @@ class MainWidget : public QWidget
   QPushButton *lib_rip_button;
   QPushButton *lib_reports_button;
   QPushButton *lib_close_button;
+  RDSimplePlayer *lib_player;
+  int lib_output_card;
+  int lib_output_port;
   QCheckBox *lib_allowdrag_box;
   QLabel *lib_allowdrag_label;
   QCheckBox *lib_showaudio_box;


### PR DESCRIPTION
This is a proposed initial implementation of the play/stop buttons in RDLibrary. This release will only enable the play/stop buttons if there is only a single cut in a cart. The button is disabled for carts with multiple cuts.

This feature will be enhanced in the future to display individual cuts for carts that contain multiple cuts.