### PR TITLE
Add Spinitorn v2 URL formatter in comments (#211)

### DIFF
--- a/conf/rlm_spinitron_plus.conf
+++ b/conf/rlm_spinitron_plus.conf
@@ -27,11 +27,13 @@ Station=wxyz
 ; Username
 ;
 ; Username for the Spinitron account to which to log the play-out.
+; Spinitron v2 users leave this blank.
 Username=user@example.com
 
 ; Password
 ;
 ; The password of the Spinitron account to which to log the play-out.
+; Spinitron v2 users set this to their API key.
 Password=changeme
 
 ; PlaylistMode

--- a/rlm/rlm_spinitron_plus.c
+++ b/rlm/rlm_spinitron_plus.c
@@ -598,6 +598,18 @@ void rlm_spinitron_plus_RLMPadDataSent(void *ptr,const struct rlm_svc *svc,
       }
 
       if(strlen(now->rlm_title)!=0) {
+	/* if the Username config is empty then use this v2 API URL
+	snprintf(msg,8192,
+		 "https://spinitron.com/api/spin/create-v1?access-token=%s&sn=%s&aw=%s&dn=%s&ln=%s&sc=%s&se=%s&sd=%d",
+		 rlm_spinitron_plus_passwords+256*i,
+		 title,
+		 artist,
+		 album,
+		 label,
+		 composer,
+		 notes,
+		 now->rlm_len/1000);
+	else use the old v1 URL */
 	snprintf(msg,8192,
 		 "https://spinitron.com/member/logthis.php?un=%s&pw=%s&sn=%s&aw=%s&dn=%s&ln=%s&sc=%s&se=%s&df=%s&st=%s&sd=%d&pm=%d",
 		 rlm_spinitron_plus_usernames+256*i,
@@ -612,6 +624,7 @@ void rlm_spinitron_plus_RLMPadDataSent(void *ptr,const struct rlm_svc *svc,
 		 rlm_spinitron_plus_stations+256*i,
 		 now->rlm_len/1000,
 		 pm);
+	/* end Spinitron v1/v2 branches */
 	if(fork()==0) {
 	  execlp("curl","curl",msg,(char *)NULL);
 	  RLMLog(ptr,LOG_WARNING,"rlm_spinitron_plus: unable to execute curl(1)");

--- a/rlm/rlm_spinitron_plus.c
+++ b/rlm/rlm_spinitron_plus.c
@@ -598,33 +598,34 @@ void rlm_spinitron_plus_RLMPadDataSent(void *ptr,const struct rlm_svc *svc,
       }
 
       if(strlen(now->rlm_title)!=0) {
-	/* if the Username config is empty then use this v2 API URL
-	snprintf(msg,8192,
-		 "https://spinitron.com/api/spin/create-v1?access-token=%s&sn=%s&aw=%s&dn=%s&ln=%s&sc=%s&se=%s&sd=%d",
-		 rlm_spinitron_plus_passwords+256*i,
-		 title,
-		 artist,
-		 album,
-		 label,
-		 composer,
-		 notes,
-		 now->rlm_len/1000);
-	else use the old v1 URL */
-	snprintf(msg,8192,
-		 "https://spinitron.com/member/logthis.php?un=%s&pw=%s&sn=%s&aw=%s&dn=%s&ln=%s&sc=%s&se=%s&df=%s&st=%s&sd=%d&pm=%d",
-		 rlm_spinitron_plus_usernames+256*i,
-		 rlm_spinitron_plus_passwords+256*i,
-		 title,
-		 artist,
-		 album,
-		 label,
-		 composer,
-		 notes,
-		 RLM_SPINITRON_PLUS_LOGGER_NAME,
-		 rlm_spinitron_plus_stations+256*i,
-		 now->rlm_len/1000,
-		 pm);
-	/* end Spinitron v1/v2 branches */
+	/* if the Username config is empty then use Spinitron v2 API, or else use v1 */
+	if ((rlm_spinitron_plus_usernames+256*i)==0) {
+	  snprintf(msg,8192,
+		   "https://spinitron.com/api/spin/create-v1?access-token=%s&sn=%s&aw=%s&dn=%s&ln=%s&sc=%s&se=%s&sd=%d",
+		   rlm_spinitron_plus_passwords+256*i,
+		   title,
+		   artist,
+		   album,
+		   label,
+		   composer,
+		   notes,
+		   now->rlm_len/1000);
+	} else {
+	  snprintf(msg,8192,
+		   "https://spinitron.com/member/logthis.php?un=%s&pw=%s&sn=%s&aw=%s&dn=%s&ln=%s&sc=%s&se=%s&df=%s&st=%s&sd=%d&pm=%d",
+		   rlm_spinitron_plus_usernames+256*i,
+		   rlm_spinitron_plus_passwords+256*i,
+		   title,
+		   artist,
+		   album,
+		   label,
+		   composer,
+		   notes,
+		   RLM_SPINITRON_PLUS_LOGGER_NAME,
+		   rlm_spinitron_plus_stations+256*i,
+		   now->rlm_len/1000,
+		   pm);
+	}
 	if(fork()==0) {
 	  execlp("curl","curl",msg,(char *)NULL);
 	  RLMLog(ptr,LOG_WARNING,"rlm_spinitron_plus: unable to execute curl(1)");


### PR DESCRIPTION
Adds a URL formatter for Spinitron v2's automation API.

Added in comments because I don't know how to write the condition for an if/else that chooses one branch when the Username RLM config has a value and the other branch when it is empty.

This PR addresses issue #211.