### PR TITLE
(Master) Disable focus of SimplePlayer buttons in RDAirplay

### DIFF
--- a/rdlibrary/rdlibrary.cpp
+++ b/rdlibrary/rdlibrary.cpp
@@ -484,6 +484,8 @@ MainWidget::MainWidget(QWidget *parent)
   lib_player->playButton()->setEnabled(false);
   lib_player->stopButton()->setEnabled(false);
   lib_player->stopButton()->setOnColor(Qt::red);
+  lib_player->playButton()->setFocusPolicy(Qt::NoFocus);
+  lib_player->stopButton()->setFocusPolicy(Qt::NoFocus);
 
 
   // 


### PR DESCRIPTION
Disabling the focus of the player buttons allows the selection of other carts/cuts using arrow keys without having to select the list again.