### PR TITLE
(Master Bug Fix) Fixed delete and voice track buttons in RDLogEdit

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -17895,4 +17895,5 @@
 	* Fixed a bug in 'configure.ac' that caused detection of FLAC
 	support to always fail.
 2018-10-27 Patrick Linstruth <patrick@deltecent.com>
-	* Fix delete and voice track buttons in rdlogedit(1)
+	* Fix delete and voice track buttons in rdlogedit(1).
+	* Fix bug in RDSimplePlayer setCart() method.

--- a/ChangeLog
+++ b/ChangeLog
@@ -17894,3 +17894,5 @@
 2018-10-23 Fred Gleason <fredg@paravelsystems.com>
 	* Fixed a bug in 'configure.ac' that caused detection of FLAC
 	support to always fail.
+2018-10-27 Patrick Linstruth <patrick@deltecent.com>
+	* Fix delete and voice track buttons in rdlogedit(1)

--- a/lib/rdsimpleplayer.cpp
+++ b/lib/rdsimpleplayer.cpp
@@ -84,6 +84,7 @@ bool RDSimplePlayer::isPlaying()
 void RDSimplePlayer::setCart(unsigned cart)
 {
   play_cart=cart;
+  play_cut="";
 }
 
 

--- a/rdlogedit/rdlogedit.cpp
+++ b/rdlogedit/rdlogedit.cpp
@@ -631,8 +631,8 @@ void MainWidget::logSelectionChangedData()
     item=(ListListViewItem *)item->nextSibling();
   }
   log_edit_button->setEnabled(count==1);
-  log_delete_button->setEnabled(count>0);
-  log_track_button->setEnabled(count==1);
+  log_delete_button->setEnabled(count>0&&rda->user()->deleteLog());
+  log_track_button->setEnabled(count==1&&rda->user()->voicetrackLog());
 }
 
 

--- a/rdlogedit/rdlogedit.cpp
+++ b/rdlogedit/rdlogedit.cpp
@@ -300,8 +300,8 @@ void MainWidget::userData()
   // Set Control Perms
   //
   log_add_button->setEnabled(rda->user()->createLog());
-  log_delete_button->setEnabled(rda->user()->deleteLog());
-  log_track_button->setEnabled(rda->user()->voicetrackLog());
+  log_delete_button->setEnabled(false);
+  log_track_button->setEnabled(false);
 }
 
 


### PR DESCRIPTION
Delete and Voice Track buttons were always enabled after selecting a log regardless of user authorization.