### PR TITLE
Rdlibrary macro

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -17955,3 +17955,5 @@
 2018-11-01 Fred Gleason <fredg@paravelsystems.com>
 	* Modified rdselect_helper(8) to use the automounter for managing
 	audio store mounts.
+2018-11-02 Patrick Linstruth <patrick@deltecent.com>
+	* Fix bugs in processing of some RML with boolean parameters.

--- a/ChangeLog
+++ b/ChangeLog
@@ -17970,3 +17970,6 @@
 	Guide.
 2018-11-02 Patrick Linstruth <patrick@deltecent.com>
 	* Fixed bug in in some RML commands with boolean paramters.
+2018-11-02 Patrick Linstruth <patrick@deltecent.com>
+	* Fix macro editor in rdlibrary(1) to no longer display
+	"--- End of cart ---" and disable sorting of columns.

--- a/lib/rdripc.cpp
+++ b/lib/rdripc.cpp
@@ -146,7 +146,7 @@ void RDRipc::sendNotification(const RDNotification &notify)
 
 void RDRipc::sendOnairFlag()
 {
-  SendCommand("TA!");
+  SendCommand(QString().sprintf("TA %d!",ripc_onair_flag));
 }
 
 
@@ -269,7 +269,7 @@ void RDRipc::DispatchCommand()
     if(!macro.isNull()) {
       QHostAddress addr;
       addr.setAddress(cmds[1]);
-      if(cmds[2].left(0)=="1") {
+      if(cmds[2].left(1)=="1") {
 	macro.setEchoRequested(true);
       }
       macro.setAddress(addr);
@@ -304,7 +304,7 @@ void RDRipc::DispatchCommand()
     int line=cmds[2].toInt();
     int mask=cmds[4].toInt();
     if((mask>0)||ripc_ignore_mask) {
-      if(cmds[3].left(0)=="0") {
+      if(cmds[3].left(1)=="0") {
 	emit gpiStateChanged(matrix,line,false);
       }
       else {
@@ -321,7 +321,7 @@ void RDRipc::DispatchCommand()
     int line=cmds[2].toInt();
     int mask=cmds[4].toInt();
     if((mask>0)||ripc_ignore_mask) {
-      if(cmds[3].left(0)=="0") {
+      if(cmds[3].left(1)=="0") {
 	emit gpoStateChanged(matrix,line,false);
       }
       else {
@@ -336,7 +336,7 @@ void RDRipc::DispatchCommand()
     }
     int matrix=cmds[1].toInt();
     int line=cmds[2].toInt();
-    if(cmds[3].left(0)=="0") {
+    if(cmds[3].left(1)=="0") {
       emit gpiMaskChanged(matrix,line,false);
     }
     else {
@@ -350,7 +350,7 @@ void RDRipc::DispatchCommand()
     }
     int matrix=cmds[1].toInt();
     int line=cmds[2].toInt();
-    if(cmds[3].left(0)=="0") {
+    if(cmds[3].left(1)=="0") {
       emit gpoMaskChanged(matrix,line,false);
     }
     else {
@@ -384,7 +384,7 @@ void RDRipc::DispatchCommand()
     if(cmds.size()!=2) {
       return;
     }
-    ripc_onair_flag=cmds[1].left(0)=="1";
+    ripc_onair_flag=cmds[1].left(1)=="1";
     emit onairFlagChanged(ripc_onair_flag);
   }
 

--- a/rdlibrary/macro_cart.cpp
+++ b/rdlibrary/macro_cart.cpp
@@ -107,7 +107,7 @@ MacroCart::MacroCart(RDCart *cart,QWidget *parent)
   rdcart_macro_list->setGeometry(100,0,430,sizeHint().height());
   rdcart_macro_list->setAllColumnsShowFocus(true);
   rdcart_macro_list->setItemMargin(5);
-  rdcart_macro_list->setSorting(0);
+  rdcart_macro_list->setSorting(-1);
   connect(rdcart_macro_list,
 	  SIGNAL(doubleClicked(Q3ListViewItem *,const QPoint &,int)),
 	  this,
@@ -195,9 +195,6 @@ void MacroCart::addMacroData()
   unsigned line;
 
   if(item==NULL) {
-    return;
-  }
-  if(item->text(0).isEmpty()) {
     line=rdcart_events->size();
   }
   else {
@@ -309,13 +306,12 @@ void MacroCart::RefreshList()
 {
   Q3ListViewItem *item;
 
-  item=new Q3ListViewItem(rdcart_macro_list);
-  item->setText(1,tr("--- End of cart ---"));
   for(int i=0;i<rdcart_events->size();i++) {
     item=new Q3ListViewItem(rdcart_macro_list);
     item->setText(0,QString().sprintf("%03d",i+1));
     item->setText(1,rdcart_events->command(i)->toString());
   }
+  SortLines();
 }
 
 
@@ -323,8 +319,16 @@ void MacroCart::RefreshLine(Q3ListViewItem *item)
 {
   int line=item->text(0).toInt()-1;
   item->setText(1,rdcart_events->command(line)->toString());
+  SortLines();
 }
 
+
+void MacroCart::SortLines()
+{
+  rdcart_macro_list->setSorting(0);
+  rdcart_macro_list->sort();
+  rdcart_macro_list->setSorting(-1);
+}
 
 void MacroCart::AddLine(unsigned line,RDMacro *cmd)
 {

--- a/rdlibrary/macro_cart.h
+++ b/rdlibrary/macro_cart.h
@@ -68,6 +68,7 @@ class MacroCart : public QWidget
   void AddLine(unsigned line,RDMacro *cmd);
   void DeleteLine(Q3ListViewItem *item);
   void UpdateLength();
+  void SortLines();
   RDCart *rdcart_cart;
   Q3ListView *rdcart_macro_list;
   QLabel *rdcart_macro_list_label;

--- a/rdlibrary/rdlibrary_cs.ts
+++ b/rdlibrary/rdlibrary_cs.ts
@@ -1140,7 +1140,7 @@ vozík</translation>
     </message>
     <message>
         <source>--- End of cart ---</source>
-        <translation>--- Konec vozíku ---</translation>
+        <translation type="obsolete">--- Konec vozíku ---</translation>
     </message>
     <message>
         <source>Line</source>

--- a/rdlibrary/rdlibrary_de.ts
+++ b/rdlibrary/rdlibrary_de.ts
@@ -1128,7 +1128,7 @@ starten</translation>
     </message>
     <message>
         <source>--- End of cart ---</source>
-        <translation>--- Ende des Carts ---</translation>
+        <translation type="obsolete">--- Ende des Carts ---</translation>
     </message>
     <message>
         <source>Line</source>

--- a/rdlibrary/rdlibrary_es.ts
+++ b/rdlibrary/rdlibrary_es.ts
@@ -1137,7 +1137,7 @@ Cartucho</translation>
     </message>
     <message>
         <source>--- End of cart ---</source>
-        <translation>--- Fin del cartucho ---</translation>
+        <translation type="obsolete">--- Fin del cartucho ---</translation>
     </message>
     <message>
         <source>Line</source>

--- a/rdlibrary/rdlibrary_fr.ts
+++ b/rdlibrary/rdlibrary_fr.ts
@@ -939,10 +939,6 @@ Cart</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>--- End of cart ---</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Line</source>
         <translation type="unfinished"></translation>
     </message>

--- a/rdlibrary/rdlibrary_nb.ts
+++ b/rdlibrary/rdlibrary_nb.ts
@@ -1124,7 +1124,7 @@ korg</translation>
     </message>
     <message>
         <source>--- End of cart ---</source>
-        <translation>--- Slutten på korga ---</translation>
+        <translation type="obsolete">--- Slutten på korga ---</translation>
     </message>
     <message>
         <source>Line</source>

--- a/rdlibrary/rdlibrary_nn.ts
+++ b/rdlibrary/rdlibrary_nn.ts
@@ -1124,7 +1124,7 @@ korg</translation>
     </message>
     <message>
         <source>--- End of cart ---</source>
-        <translation>--- Slutten på korga ---</translation>
+        <translation type="obsolete">--- Slutten på korga ---</translation>
     </message>
     <message>
         <source>Line</source>

--- a/rdlibrary/rdlibrary_pt_BR.ts
+++ b/rdlibrary/rdlibrary_pt_BR.ts
@@ -1126,7 +1126,7 @@ Cartão</translation>
     </message>
     <message>
         <source>--- End of cart ---</source>
-        <translation>-- Fim do Cartão --</translation>
+        <translation type="obsolete">-- Fim do Cartão --</translation>
     </message>
     <message>
         <source>Line</source>


### PR DESCRIPTION
This PR changes the MacroCart editor in RDLibrary to better reflect the execution of macros.

Macros are always executed in Line order, so having the ability to sort the columns may give the false impression that macros will execute in the sorted order. Also, the "--- End of cart ---" display is superfluous.

MacroCart will now always display the macros sorted by Line and will not allow the user to change the sort order.  The "--- End of cart ---" line has also been removed.