### PR TITLE
(Master) Changed 'CART.SCHED_CODES' default to '.'

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -18007,3 +18007,6 @@
 	* Fixed a regression in rdpanel(1) background image.
 2018-11-09 Fred Gleason <fredg@paravelsystems.com>
 	* Removed a debugging printf in rdpanel(1).
+2018-11-12 Patrick Linstruth <patrick@deltecent.com>
+	* Changed 'CART.SCHED_CODES' default to '.'.
+	* Incremented the database version to 299.

--- a/lib/dbversion.h
+++ b/lib/dbversion.h
@@ -24,7 +24,7 @@
 /*
  * Current Database Version
  */
-#define RD_VERSION_DATABASE 298
+#define RD_VERSION_DATABASE 299
 
 
 #endif  // DBVERSION_H

--- a/utils/rddbmgr/revertschema.cpp
+++ b/utils/rddbmgr/revertschema.cpp
@@ -41,6 +41,18 @@ bool MainObject::RevertSchema(int cur_schema,int set_schema,QString *err_msg)
   // NEW SCHEMA REVERSIONS GO HERE...
 
   //
+  // Revert 299
+  //
+  if((cur_schema==299)&&(set_schema<cur_schema)) {
+    sql=QString("alter table CART alter column SCHED_CODES set default NULL");
+    if(!RDSqlQuery::apply(sql,err_msg)) {
+      return false;
+    }
+
+    WriteSchemaVersion(--cur_schema);
+  }
+
+  //
   // Revert 298
   //
   if((cur_schema==298)&&(set_schema<cur_schema)) {

--- a/utils/rddbmgr/schemamap.cpp
+++ b/utils/rddbmgr/schemamap.cpp
@@ -140,7 +140,7 @@ void MainObject::InitializeSchemaMap() {
   global_version_map["2.17"]=268;
   global_version_map["2.18"]=272;
   global_version_map["2.19"]=275;
-  global_version_map["3.0"]=298;
+  global_version_map["3.0"]=299;
 }
 
 

--- a/utils/rddbmgr/updateschema.cpp
+++ b/utils/rddbmgr/updateschema.cpp
@@ -9803,6 +9803,14 @@ bool MainObject::UpdateSchema(int cur_schema,int set_schema,QString *err_msg)
 
   // NEW SCHEMA UPDATES GO HERE...
 
+  if((cur_schema<299)&&(set_schema>cur_schema)) {
+    sql=QString("alter table CART alter column SCHED_CODES set default '.'");
+    if(!RDSqlQuery::apply(sql,err_msg)) {
+      return false;
+    }
+
+    WriteSchemaVersion(++cur_schema);
+  }
 
   //
   // Maintainer's Note:


### PR DESCRIPTION
This change will make sure new carts have a scheduler code of "." rather than "".