### PR TITLE
(Master Bug) Fixed erase marker error in the 'Edit Audio' dialog.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -18508,3 +18508,5 @@
 2019-02-19 Fred Gleason <fredg@paravelsystems.com>
 	* Fixed a bug in rdadmin(1) that threw a SQL error when deleting
 	a host entry.
+2019-02-21 Patrick Linstruth <patrick@deltecent.com>
+	* Fixed erase marker error in the 'Edit Audio' dialog.

--- a/lib/rdedit_audio.cpp
+++ b/lib/rdedit_audio.cpp
@@ -2686,7 +2686,7 @@ void RDEditAudio::EraseCursor(int xpos,int ypos,int xsize,int ysize,int chan,
 {
   int x;
 
-  if((edit_hscroll==NULL)||(prev<0)||((prev==0)&&(samp<0))) {
+  if((edit_hscroll==NULL)||(prev<0)) {
     return;
   }
   x=(int)((double)(samp-edit_hscroll->value())/edit_factor_x);


### PR DESCRIPTION
This fixes marker not erasing properly upon remove.