### PR TITLE
(Regression) Fixes clock scheduler rules in rdlogmanager(1) scheduler

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -18560,3 +18560,6 @@
 	Guide.
 2019-03-28 Fred Gleason <fredg@paravelsystems.com>
 	* Fixed a typo in the remarks in 'apis/pypad/scripts/pypad_serial.py'.
+2019-04-02 Patrick Linstruth <patrick@deltecent.com>
+	* Fixed a regression that broke clock scheduler rules
+	in rdlogmanager(1).

--- a/lib/schedcartlist.cpp
+++ b/lib/schedcartlist.cpp
@@ -18,162 +18,171 @@
 //   Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 //
 
-#include <schedcartlist.h>
+#include <stdio.h>
+#include "schedcartlist.h"
 
 SchedCartList::SchedCartList(int listsize)
 {
-	cartnum=new unsigned[listsize];
-	cartlen=new int[listsize];
-	stackid=new int[listsize];
-	artist=new QString[listsize];
-	sched_codes=new QString[listsize];
-	itemcounter=0;
+  cartnum=new unsigned[listsize];
+  cartlen=new int[listsize];
+  stackid=new int[listsize];
+  artist=new QString[listsize];
+  sched_codes=new QString[listsize];
+  itemcounter=0;
 }
 
 SchedCartList::~SchedCartList()
 {
-	delete []cartnum;
-	delete []cartlen;
-	delete []stackid;
-	delete []artist;
-	delete []sched_codes;
+  delete []cartnum;
+  delete []cartlen;
+  delete []stackid;
+  delete []artist;
+  delete []sched_codes;
 }
 
-//
-// stack_schedcodes should no longer be needed. Possibly remove at a later date. P. Linstruth 01/12/2019
-//
 void SchedCartList::insertItem(unsigned cartnumber,int cartlength,int stack_id,QString stack_artist,QString stack_schedcodes)
 {
-	cartnum[itemcounter]=cartnumber;
-	cartlen[itemcounter]=cartlength;
-	stackid[itemcounter]=stack_id;
-	artist[itemcounter]=stack_artist.lower().replace(" ","");
-        sched_codes[itemcounter]=stack_schedcodes;	
-	itemcounter++;
+  cartnum[itemcounter]=cartnumber;
+  cartlen[itemcounter]=cartlength;
+  stackid[itemcounter]=stack_id;
+  artist[itemcounter]=stack_artist.lower().replace(" ","");
+  if(stack_schedcodes=="") {
+    stack_schedcodes=".";
+  }
+  sched_codes[itemcounter]=stack_schedcodes;  
+  itemcounter++;
 }
 
 
 void SchedCartList::removeItem(int itemnumber)
 {
-	for(int i=itemnumber;i<(itemcounter-1);i++)
-	{
-		cartnum[i]=cartnum[i+1];
-		cartlen[i]=cartlen[i+1];
-		stackid[i]=stackid[i+1];
-		artist[i]=artist[i+1];
-		sched_codes[i]=sched_codes[i+1];
-	}
-	itemcounter--;
+  for(int i=itemnumber;i<(itemcounter-1);i++) {
+    cartnum[i]=cartnum[i+1];
+    cartlen[i]=cartlen[i+1];
+    stackid[i]=stackid[i+1];
+    artist[i]=artist[i+1];
+    sched_codes[i]=sched_codes[i+1];
+  }
+  itemcounter--;
 }
 
 bool SchedCartList::removeIfCode(int itemnumber,QString test_code)
 {
-    QString test = test_code;
-    test+="          ";
-    test=test.left(11);
+  QString test = test_code;
+  test+="          ";
+  test=test.left(11);
 
-    if (sched_codes[itemnumber].find(test)!=-1)
-      {
-	for(int i=itemnumber;i<(itemcounter-1);i++)
-	{
-		cartnum[i]=cartnum[i+1];
-		cartlen[i]=cartlen[i+1];
-		stackid[i]=stackid[i+1];
-		artist[i]=artist[i+1];
-		sched_codes[i]=sched_codes[i+1];
-	}
-	itemcounter--;
-        return true;
-      }
-    return false; 
+  if (sched_codes[itemnumber].find(test)!=-1) {
+    for(int i=itemnumber;i<(itemcounter-1);i++) {
+      cartnum[i]=cartnum[i+1];
+      cartlen[i]=cartlen[i+1];
+      stackid[i]=stackid[i+1];
+      artist[i]=artist[i+1];
+      sched_codes[i]=sched_codes[i+1];
+    }
+    itemcounter--;
+    return true;
+  }
+  return false; 
 }
 
 bool SchedCartList::itemHasCode(int itemnumber,QString test_code)
 {
-    QString test=test_code;
-    test+="          ";
-    test=test.left(11);
+  QString test=test_code;
+  test+="          ";
+  test=test.left(11);
 
-    if (sched_codes[itemnumber].find(test)!=-1)
-      return true;
-    else
-      return false;
+  if (sched_codes[itemnumber].find(test)!=-1) {
+    return true;
+  }
+  else {
+    return false;
+  }
 }
 
 
+bool SchedCartList::itemHasCodes(int itemnumber,QStringList test_codes)
+{
+  for (int i=0;i<test_codes.size();i++) {
+    QString test=test_codes.at(i);
+    test+="          ";
+    test=test.left(11);
+
+    if (sched_codes[itemnumber].find(test)!=-1) {
+      return true;
+    }
+  }
+  return false;
+}
+
 void SchedCartList::save(void)
 {
-	savecartnum=new unsigned[itemcounter];
-	savecartlen=new int[itemcounter];
-	savestackid=new int[itemcounter];
-	saveartist=new QString[itemcounter];
-	save_sched_codes=new QString[itemcounter];
+  savecartnum=new unsigned[itemcounter];
+  savecartlen=new int[itemcounter];
+  savestackid=new int[itemcounter];
+  saveartist=new QString[itemcounter];
+  save_sched_codes=new QString[itemcounter];
 
-	saveitemcounter=itemcounter;	
-	for(int i=0;i<saveitemcounter;i++)
-	{
-		savecartnum[i]=cartnum[i];
-		savecartlen[i]=cartlen[i];
-		savestackid[i]=stackid[i];
-		saveartist[i]=artist[i];
-		save_sched_codes[i]=sched_codes[i];
-	}
+  saveitemcounter=itemcounter;  
+  for(int i=0;i<saveitemcounter;i++) {
+    savecartnum[i]=cartnum[i];
+    savecartlen[i]=cartlen[i];
+    savestackid[i]=stackid[i];
+    saveartist[i]=artist[i];
+    save_sched_codes[i]=sched_codes[i];
+  }
 }
 
 
 void SchedCartList::restore(void)
 {
-	if(itemcounter==0)
-	{
-		for(int i=0;i<saveitemcounter;i++)
-		{
-			cartnum[i]=savecartnum[i];
-			cartlen[i]=savecartlen[i];
-			stackid[i]=savestackid[i];
-			artist[i]=saveartist[i];
-			sched_codes[i]=save_sched_codes[i];
-		}
-		itemcounter=saveitemcounter;	
-	}
-	delete []savecartnum;
-	delete []savecartlen;
-	delete []savestackid;
-	delete []saveartist;
-	delete []save_sched_codes;
+  if(itemcounter==0) {
+    for(int i=0;i<saveitemcounter;i++) {
+      cartnum[i]=savecartnum[i];
+      cartlen[i]=savecartlen[i];
+      stackid[i]=savestackid[i];
+      artist[i]=saveartist[i];
+      sched_codes[i]=save_sched_codes[i];
+    }
+    itemcounter=saveitemcounter;  
+  }
+  delete []savecartnum;
+  delete []savecartlen;
+  delete []savestackid;
+  delete []saveartist;
+  delete []save_sched_codes;
 }
 
 
 
-unsigned SchedCartList::getItemCartnumber(int itemnumber)
+unsigned SchedCartList::getItemCartNumber(int itemnumber)
 {
-	return cartnum[itemnumber];
+  return cartnum[itemnumber];
 }
 
 int SchedCartList::getItemStackid(int itemnumber)
 {
-	return stackid[itemnumber];
+  return stackid[itemnumber];
 }
 
 QString SchedCartList::getItemArtist(int itemnumber)
 {
-	return artist[itemnumber];
+  return artist[itemnumber];
 }
 
 QString SchedCartList::getItemSchedCodes(int itemnumber)
 {
-	return sched_codes[itemnumber];
+  return sched_codes[itemnumber];
 }
 
-int SchedCartList::getItemCartlength(int itemnumber)
+int SchedCartList::getItemCartLength(int itemnumber)
 {
-	return cartlen[itemnumber];
+  return cartlen[itemnumber];
 }
 
 
 int SchedCartList::getNumberOfItems(void)
 {
-	return itemcounter;
+  return itemcounter;
 }
  
-
-

--- a/lib/schedcartlist.h
+++ b/lib/schedcartlist.h
@@ -22,6 +22,7 @@
 #define SCHEDCARTLIST_H
 
 #include <qsqldatabase.h>
+#include <qstringlist.h>
 
 class SchedCartList
 {
@@ -32,8 +33,9 @@ class SchedCartList
    void removeItem(int itemnumber);
    bool removeIfCode(int itemnumber,QString test_code);
    bool itemHasCode(int itemnumber,QString test_code);
-   unsigned getItemCartnumber(int itemnumber);
-   int getItemCartlength(int itemnumber);
+   bool itemHasCodes(int itemnumber,QStringList test_codes);
+   unsigned getItemCartNumber(int itemnumber);
+   int getItemCartLength(int itemnumber);
    int getItemStackid(int itemnumber);
    QString getItemArtist(int itemnumber);
    QString getItemSchedCodes(int itemnumber);


### PR DESCRIPTION
Also fixed some formatting...

One issue to consider. One reason for moving a cart's schedule codes to its own table was to remove the 255 character limit (23 codes). Unfortunately, scheduler codes are stored in the stack in the same, old format with a maximum of 255 characters.