### PR TITLE
(Master Bug) Fixed bug in rdlogmanager(1) scheduler rules

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -18645,3 +18645,6 @@
 	* Cleaned up a compiler warning for 'RDMacroEvent'.
 2019-05-03 Fred Gleason <fredg@paravelsystems.com>
 	* Updated the package version to 3.0.0rc02.
+2019-05-04 Patrick Linstruth <patrick@deltecent.com>
+	* Fixed bug in clock schedule rules where "or After" schedule codes
+	were not displayed correctly.

--- a/lib/rdschedruleslist.cpp
+++ b/lib/rdschedruleslist.cpp
@@ -64,7 +64,7 @@ RDSchedRulesList::RDSchedRulesList(QString clockname,RDConfig *config)
       min_wait[i] = q1->value(1).toInt();
       not_after[i] = q1->value(2).toString();
       or_after[i] = q1->value(3).toString();
-      or_after_II[i] = q1->value(3).toString();
+      or_after_II[i] = q1->value(4).toString();
     }
     else {
       max_row[i] = 1;

--- a/rdlogmanager/edit_schedcoderules.cpp
+++ b/rdlogmanager/edit_schedcoderules.cpp
@@ -146,7 +146,7 @@ editSchedCodeRules::editSchedCodeRules(Q3ListViewItem *item,
     }
   comboBox_not_after->setCurrentText(item->text(3));
   comboBox_or_after->setCurrentText(item->text(4));
-  comboBox_or_after->setCurrentText(item->text(5));
+  comboBox_or_after_II->setCurrentText(item->text(5));
 
   label_description = new QLabel(this);
   label_description->setGeometry( QRect( 200, 40, 300, 40 ) );


### PR DESCRIPTION
Fixed bug in clock schedule rules where "or After" schedule code were not displayed correctly.