### PR TITLE
(3.0.0rc02) Add error dialog to rdsoftkeys(1)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -18678,3 +18678,6 @@
 	'--end-startup-after-rdpadengined', '--end-startup-after-rdvairplayd',
 	and '--end-startup-after-rdrepld' command line switches to
 	rdservice(8).
+2019-05-22 Patrick Linstruth <patrick@deltecent.com>
+	* Display error dialog in rdsoftkeys(1) if no defintions are
+	found in map file.

--- a/utils/rdsoftkeys/rdsoftkeys.cpp
+++ b/utils/rdsoftkeys/rdsoftkeys.cpp
@@ -157,6 +157,17 @@ MainWidget::MainWidget(QWidget *parent)
     }
     n++;
   }
+
+  //
+  // If no softkeys have been defined, gracefully exit
+  //
+  if (!key_macros.size()) {
+    QMessageBox::critical(this, tr("RDSoftKeys"),
+       tr(QString("No SoftKey definitions found in file\n%1")
+       .arg(map_filename)));
+    exit(1);
+  }
+
   if((key_macros.size()%key_columns)==0) {
     key_ysize-=60;
   }


### PR DESCRIPTION
If now softkey definitions are found in the specified map file, rdsoftkeys(1) will display and error dialog and exit gracefully.

Addresses issue #427 