### PR TITLE
(3.0.0rc02 Bug) Fixed bug in rdlogmanager(1) deconflicting rules.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -18696,3 +18696,5 @@
 2019-05-24 Fred Gleason <fredg@paravelsystems.com>
 	* Fixed a regression in rdgpimon(1) that caused GPIO status
 	to fail to be displayed in the status widgets.
+2019-05-27 Patrick Linstruth <patrick@deltecent.com>
+	* Fixed bug in rdlogmanager(1) deconflicting rules.

--- a/lib/rdevent_line.cpp
+++ b/lib/rdevent_line.cpp
@@ -699,8 +699,8 @@ bool RDEventLine::generateLog(QString logname,const QString &svcname,
             *report+=QObject::tr(" with sched code(s): ")+HaveCode()+" "+HaveCode2();
           }
           *report+="\n";
+          schedCL->restore();
         }
-        schedCL->restore();
       }
       
       //
@@ -731,8 +731,8 @@ bool RDEventLine::generateLog(QString logname,const QString &svcname,
             *report+=QObject::tr(" with sched code(s): ")+HaveCode()+" "+HaveCode2();
           }
           *report+="\n";
+          schedCL->restore();
         }
-        schedCL->restore();
       }
       
       // Clock Scheduler Rules
@@ -779,8 +779,8 @@ bool RDEventLine::generateLog(QString logname,const QString &svcname,
 	  *report+=time.toString("hh:mm:ss")+" "+
 	    QObject::tr("Rule broken: Max. in a Row/Min. Wait for ")+
 	    q->value(0).toString()+"\n";
+	  schedCL->restore();
 	}
-	schedCL->restore();
 
 	// do not play after
 	if(q->value(3).toString()!="") {


### PR DESCRIPTION
There was a bug where the scheduler was restoring excluded carts when it wasn't supposed to. I believe this problem also exists in 2.19.