### PR TITLE
(3.0.0rc02 Bug) Fixed bug in RDWaveFile that exhaused file handles.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -18696,3 +18696,5 @@
 2019-05-24 Fred Gleason <fredg@paravelsystems.com>
 	* Fixed a regression in rdgpimon(1) that caused GPIO status
 	to fail to be displayed in the status widgets.
+2019-05-30 Patrick Linstruth <patrick@deltecent.com>
+	* Fixed bug in 'RDWaveFile' class that exhausted file handles.

--- a/lib/rdwavefile.cpp
+++ b/lib/rdwavefile.cpp
@@ -231,7 +231,7 @@ bool RDWaveFile::openWave(RDWaveData *data)
   if((fd=open(wave_file_name.toUtf8(),O_RDONLY))<0) {
     return false;
   }
-  if(!wave_file.open(fd,QIODevice::ReadOnly)) {
+  if(!wave_file.open(fd,QIODevice::ReadOnly,QFile::AutoCloseHandle)) {
     return false;
   }
   switch(GetType(wave_file.handle())) {


### PR DESCRIPTION
> When a QFile is opened using this function, behaviour of close() is controlled by the ```handleFlags``` argument.  If ```AutoCloseHandle``` is specified, and this function succeeds, then calling close() closes the adopted handle.  Otherwise, close() does not actually close the file, but only flushes it.