### PR TITLE
(3.0.0rc02 Feature) Added new '--orphaned-*' command line switches to rddbmgr(8).

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -18702,7 +18702,7 @@
 2019-05-31 Patrick Linstruth <patrick@deltecent.com>
 	* Fixed bug in rdlogmanager(1) deconflicting rules.
 2019-05-31 Patrick Linstruth <patrick@deltecent.com>
-	* Added RD_PREFIX to rddbmgr(1) path and process start error
+	* Added RD_PREFIX to rddbmgr(8) path and process start error
 	message dialog to rddbconfig(1).
 2019-05-31 Patrick Linstruth <patrick@deltecent.com>
 	* Fixed bug in 'RDWaveFile' class that exhausted file handles.
@@ -18710,3 +18710,6 @@
 	* Fixed a bug in rdlibrary(1) that made it impossible to configure
 	more than 100 cuts in a cart using 'By Specified Order' scheduling
 	rules.
+2019-06-02 Patrick Linstruth <patrick@deltecent.com>
+	* Added '--orphaned-audio', '--orphaned-carts', '--orphaned-cuts',
+	and '--orphaned-tracks' command line switches to rddbmgr(8).

--- a/docs/manpages/rddbmgr.xml
+++ b/docs/manpages/rddbmgr.xml
@@ -204,6 +204,50 @@
 
     <varlistentry>
       <term>
+	<option>--orphaned-audio</option>
+      </term>
+      <listitem>
+	<para>
+	  Disable all checks. Add check for orphaned audio files.
+	</para>
+      </listitem>
+    </varlistentry>
+
+    <varlistentry>
+      <term>
+	<option>--orphaned-carts</option>
+      </term>
+      <listitem>
+	<para>
+	  Disable all checks. Add check for orphaned carts.
+	</para>
+      </listitem>
+    </varlistentry>
+
+    <varlistentry>
+      <term>
+	<option>--orphaned-cuts</option>
+      </term>
+      <listitem>
+	<para>
+	  Disable all checks. Add check for orphaned cuts.
+	</para>
+      </listitem>
+    </varlistentry>
+
+    <varlistentry>
+      <term>
+	<option>--orphaned-tracks</option>
+      </term>
+      <listitem>
+	<para>
+	  Disable all checks. Add check for orphaned voice tracks.
+	</para>
+      </listitem>
+    </varlistentry>
+
+    <varlistentry>
+      <term>
 	<option>--rehash=</option><replaceable>target</replaceable>
       </term>
       <listitem>

--- a/utils/rddbmgr/check.cpp
+++ b/utils/rddbmgr/check.cpp
@@ -51,7 +51,7 @@ bool MainObject::Check(QString *err_msg)
   //
   // Recover Audio
   //
-  if(!db_relink_audio.isEmpty()) {
+  if((db_check_all)&&!db_relink_audio.isEmpty()) {
     RelinkAudio(db_relink_audio);
     return true;
   }
@@ -59,63 +59,79 @@ bool MainObject::Check(QString *err_msg)
   //
   // Check Table Attributes
   //
-  printf("Checking DB/table attributes...\n");
-  CheckTableAttributes();
-  printf("done.\n\n");
+  if(db_check_all) {
+    printf("Checking DB/table attributes...\n");
+    CheckTableAttributes();
+    printf("done.\n\n");
+  }
 
   //
   // Check for Orphaned Voice Tracks
   //
-  printf("Checking voice tracks...\n");
-  CheckOrphanedTracks();
-  printf("done.\n\n");
+  if(db_check_all||db_check_orphaned_tracks) {
+    printf("Checking voice tracks...\n");
+    CheckOrphanedTracks();
+    printf("done.\n\n");
+  }
 
   //
   // Check for stale reservations
   //
-  printf("Checking for stale cart reservations...\n");
-  CheckPendingCarts();
-  printf("done.\n\n");
+  if(db_check_all) {
+    printf("Checking for stale cart reservations...\n");
+    CheckPendingCarts();
+    printf("done.\n\n");
+  }
 
   //
   // Check for orphaned carts
   //
-  printf("Checking for orphaned carts...\n");
-  CheckOrphanedCarts();
-  printf("done.\n\n");
+  if(db_check_all||db_check_orphaned_carts) {
+    printf("Checking for orphaned carts...\n");
+    CheckOrphanedCarts();
+    printf("done.\n\n");
+  }
 
   //
   // Check for orphaned cuts
   //
-  printf("Checking for orphaned cuts...\n");
-  CheckOrphanedCuts();
-  printf("done.\n\n");
+  if(db_check_all||db_check_orphaned_cuts) {
+    printf("Checking for orphaned cuts...\n");
+    CheckOrphanedCuts();
+    printf("done.\n\n");
+  }
 
   //
   // Check Cart->Cut Counts
   //
-  printf("Checking cart->cuts counters...\n");
-  CheckCutCounts();
-  printf("done.\n\n");
+  if(db_check_all) {
+    printf("Checking cart->cuts counters...\n");
+    CheckCutCounts();
+    printf("done.\n\n");
+  }
 
   //
   // Check Orphaned Audio
   //
-  printf("Checking for orphaned audio...\n");
-  CheckOrphanedAudio();
-  printf("done.\n\n");
+  if(db_check_all||db_check_orphaned_audio) {
+    printf("Checking for orphaned audio...\n");
+    CheckOrphanedAudio();
+    printf("done.\n\n");
+  }
 
   //
   // Validating Audio Lengths
   //
-  printf("Validating audio lengths (this may take some time)...\n");
-  ValidateAudioLengths();
-  printf("done.\n\n");
+  if(db_check_all) {
+    printf("Validating audio lengths (this may take some time)...\n");
+    ValidateAudioLengths();
+    printf("done.\n\n");
+  }
 
   //
   // Rehash
   //
-  if(!db_rehash.isEmpty()) {
+  if((db_check_all)&&!db_rehash.isEmpty()) {
     printf("Checking hashes...\n");
     Rehash(db_rehash);
     printf("done.\n\n");

--- a/utils/rddbmgr/rddbmgr.cpp
+++ b/utils/rddbmgr/rddbmgr.cpp
@@ -53,6 +53,12 @@ MainObject::MainObject(QObject *parent)
   db_relink_audio="";
   db_relink_audio_move=false;
 
+  db_check_all=true;
+  db_check_orphaned_audio=false;
+  db_check_orphaned_carts=false;
+  db_check_orphaned_cuts=false;
+  db_check_orphaned_tracks=false;
+
   //
   // Check that we're 'root'
   //
@@ -203,6 +209,26 @@ MainObject::MainObject(QObject *parent)
     }
     if(cmd->key(i)=="--rehash") {
       db_rehash=cmd->value(i);
+      cmd->setProcessed(i,true);
+    }
+    if(cmd->key(i)=="--orphaned-audio") {
+      db_check_all=false;
+      db_check_orphaned_audio=true;
+      cmd->setProcessed(i,true);
+    }
+    if(cmd->key(i)=="--orphaned-carts") {
+      db_check_all=false;
+      db_check_orphaned_carts=true;
+      cmd->setProcessed(i,true);
+    }
+    if(cmd->key(i)=="--orphaned-cuts") {
+      db_check_all=false;
+      db_check_orphaned_cuts=true;
+      cmd->setProcessed(i,true);
+    }
+    if(cmd->key(i)=="--orphaned-tracks") {
+      db_check_all=false;
+      db_check_orphaned_tracks=true;
       cmd->setProcessed(i,true);
     }
 

--- a/utils/rddbmgr/rddbmgr.h
+++ b/utils/rddbmgr/rddbmgr.h
@@ -132,6 +132,11 @@ class MainObject : public QObject
   bool db_verbose;
   bool db_yes;
   bool db_no;
+  bool db_check_all;
+  bool db_check_orphaned_audio;
+  bool db_check_orphaned_tracks;
+  bool db_check_orphaned_carts;
+  bool db_check_orphaned_cuts;
   QString db_orphan_group_name;
   QString db_dump_cuts_dir;
   QString db_rehash;


### PR DESCRIPTION
I have several remote workstations and move files around using ```rsync```. I needed a way to only check for orphaned files on these remote workstations.