### PR TITLE
Disregard offset in Segue marker when importing AudioVAULT files.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -18880,3 +18880,6 @@
 2019-07-22 Fred Gleason <fredg@paravelsystems.com>
 	* Fixed a regression in rdairplay(1) that caused a spurious 'Log
 	in use' error to be generated when attempting to save a log.
+2019-07-23 Dennis Graiani <dennis.graiani@gmail.com>
+	* Modified rdwavefile.cpp to set Segue End marker to the End Audio
+	marker when importing audio from AudioVAULT.

--- a/lib/rdwavefile.cpp
+++ b/lib/rdwavefile.cpp
@@ -3077,7 +3077,7 @@ bool RDWaveFile::GetAv10(int fd)
 		if(ok) {
 		  if(wave_data!=NULL) {
 		    wave_data->setSegueStartPos(pos);
-		    wave_data->setSegueEndPos(pos+offset);
+		    wave_data->setSegueEndPos(wave_data->endPos());
 		    wave_data->setMetadataFound(true);
 		  }
 		}


### PR DESCRIPTION
In AudioVAULT, the length of the SEC tone does not affect how long the segue lasts.   This should be reflected when importing audio files from AV.

I've had to go into the database and move the segue end markers to the end of the audio every time I've imported a library from AudioVAULT.

This pull requests sets the segue end marker to the end of the audio when importing audio from AV.