### PR TITLE
Set log_cut_number in RDLogLine::loadCart().

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -19749,3 +19749,6 @@
 	* Fixed a regression in rdairplay(1) that caused two events to be
 	started by a single spacebar tap if a SoundPanel event had been
 	played previously.
+2020-03-28 David Klann <dklann@linux.com>
+	* Fixed a regression in rdexport(1) that caused exported file
+	names to be constructed improperly.

--- a/lib/rdlog_line.cpp
+++ b/lib/rdlog_line.cpp
@@ -2038,6 +2038,7 @@ void RDLogLine::loadCart(int cartnum,int cutnum)
       log_average_segue_length=segueStartPoint(RDLogLine::AutoPointer)-
        startPoint(RDLogLine::AutoPointer);
     }
+    log_cut_number=cutnum;
     log_outcue=q->value(10).toString();
     log_isrc=q->value(11).toString();
     log_isci=q->value(12).toString();


### PR DESCRIPTION
It appears to me as if this was left out of the changes introduced in commit 6eee8cb.

This PR fixes #548 