### PR TITLE
Modified rdairplay(1) to always scroll log to the top when using the hour selector.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -19749,3 +19749,6 @@
 	* Fixed a regression in rdairplay(1) that caused two events to be
 	started by a single spacebar tap if a SoundPanel event had been
 	played previously.
+2020-04-01 Patrick Linstruth <patrick@deltecent.com>
+	* Modified rdairplay(1) to always scroll log to the top when using
+	the hour selector.

--- a/rdairplay/list_log.cpp
+++ b/rdairplay/list_log.cpp
@@ -586,6 +586,8 @@ void ListLog::selectHour(int hour)
   while(item!=NULL) {
     if(PredictedStartHour(item)==hour) {
       list_log_list->clearSelection();
+      // Always start from the bottom so visible item is at the top
+      list_log_list->ensureItemVisible(list_log_list->lastItem());
       list_log_list->ensureItemVisible(item);
       list_log_list->setSelected(item,true);
       return;


### PR DESCRIPTION
Resolves #555 