### PR TITLE
Modified rdlogmanager(1) to disable merge buttons

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -19749,3 +19749,6 @@
 	* Fixed a regression in rdairplay(1) that caused two events to be
 	started by a single spacebar tap if a SoundPanel event had been
 	played previously.
+2020-04-04 Patrick Linstruth <patrick@deltecent.com>
+	* Modified rdlogmanager(1) to disable merge buttons if the selected
+	log does not contain any import links.

--- a/rdlogmanager/generate_log.cpp
+++ b/rdlogmanager/generate_log.cpp
@@ -599,6 +599,7 @@ void GenerateLog::UpdateControls()
     }
     else {
       gen_music_enabled=false;
+      gen_music_button->setDisabled(true);
       gen_mus_merged_label->setPixmap(*gen_whiteball_map);
     }
     if(log->linkQuantity(RDLog::SourceTraffic)>0) {
@@ -612,6 +613,7 @@ void GenerateLog::UpdateControls()
     }
     else {
       gen_traffic_enabled=false;
+      gen_traffic_button->setDisabled(true);
       gen_tfc_merged_label->setPixmap(*gen_whiteball_map);
     }
   }


### PR DESCRIPTION
Disable merge buttons if the selected log does not contain any import links. Fixes #557 