### PR TITLE
fixed -Werror=format-string errors with gcc-9.2.0 (fixes #572)

### DIFF
--- a/lib/rdmulticaster.cpp
+++ b/lib/rdmulticaster.cpp
@@ -65,8 +65,8 @@ void RDMulticaster::subscribe(const QHostAddress &addr)
     mreq.imr_ifindex=0;
     if(setsockopt(multi_socket->socket(),IPPROTO_IP,IP_ADD_MEMBERSHIP,
 		  &mreq,sizeof(mreq))<0) {
-      fprintf(stderr,tr("Unable to subscribe to multicast address")+" \""+
-	      addr.toString()+"\" ["+QString(strerror(errno))+"]");
+      fprintf(stderr,tr("Unable to subscribe to multicast address")+" \"%s\" [%s]",
+	      addr.toString(),QString(strerror(errno)));
     }
   }
 }

--- a/rdadmin/rdadmin.cpp
+++ b/rdadmin/rdadmin.cpp
@@ -71,7 +71,7 @@ void PrintError(const QString &str,bool interactive)
     QMessageBox::warning(NULL,QObject::tr("RDAdmin Error"),str);
   }
   else {
-    fprintf(stderr,QString().sprintf("rdadmin: %s\n",(const char *)str));
+    fprintf(stderr,"rdadmin: %s\n",(const char *)str));
   }
 }
 

--- a/tests/datedecode_test.cpp
+++ b/tests/datedecode_test.cpp
@@ -85,7 +85,7 @@ MainObject::MainObject(QObject *parent)
   //
   QString err (tr("datedecode_test: "));
   if(!RDOpenDb(&schema,&err,config)) {
-    fprintf(stderr,err.ascii());
+    fprintf(stderr,"%s",err.ascii());
     delete cmd;
     exit(256);
   }

--- a/tests/log_unlink_test.cpp
+++ b/tests/log_unlink_test.cpp
@@ -90,7 +90,7 @@ MainObject::MainObject(QObject *parent)
   //
   QString err (tr("upload_test: "));
   if(!RDOpenDb(&schema,&err,test_config)) {
-    fprintf(stderr,err.ascii());
+    fprintf(stderr,"%s",err.ascii());
     delete cmd;
     exit(256);
   }

--- a/tests/reserve_carts_test.cpp
+++ b/tests/reserve_carts_test.cpp
@@ -94,7 +94,7 @@ MainObject::MainObject(QObject *parent)
   //
   QString err (tr("upload_test: "));
   if(!RDOpenDb(&schema,&err,config)) {
-    fprintf(stderr,err.ascii());
+    fprintf(stderr,"%s",err.ascii());
     delete cmd;
     exit(256);
   }

--- a/tests/upload_test.cpp
+++ b/tests/upload_test.cpp
@@ -126,7 +126,7 @@ MainObject::MainObject(QObject *parent)
   QString err (tr("upload_test: "));
   QSqlDatabase *db=RDInitDb(&schema,&err);
   if(!db) {
-    fprintf(stderr,err.ascii());
+    fprintf(stderr,"%s",err.ascii());
     delete cmd;
     exit(256);
   }

--- a/utils/rdalsaconfig/rdalsaconfig.cpp
+++ b/utils/rdalsaconfig/rdalsaconfig.cpp
@@ -323,7 +323,7 @@ void MainWidget::SaveConfig(const QString &filename) const
     return;
   }
   for(int i=0;i<alsa_other_lines.size();i++) {
-    fprintf(f,alsa_other_lines.at(i));
+    fprintf(f,"%s",alsa_other_lines.at(i));
   }
   fprintf(f,"%s\n",START_MARKER);
   QModelIndexList indexes=alsa_system_list->selectionModel()->selectedIndexes();

--- a/utils/rdalsaconfig/rdalsamodel.cpp
+++ b/utils/rdalsaconfig/rdalsamodel.cpp
@@ -277,7 +277,7 @@ bool RDAlsaModel::saveConfig(const QString &filename)
     return false;
   }
   for(int i=0;i<model_other_lines.size();i++) {
-    fprintf(f,model_other_lines.at(i));
+    fprintf(f,"%s",model_other_lines.at(i));
   }
   fprintf(f,"%s\n",START_MARKER);
   for(int i=0;i<model_alsa_cards.size();i++) {


### PR DESCRIPTION
gcc warns about non-constant format strings