### PR TITLE
Correct column settings in Dropbox list view.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -19920,3 +19920,5 @@
 	* Incremented the package version to 3.4.0int1.
 2020-07-21 Fred Gleason <fredg@paravelsystems.com>
 	* Incremented the package version to 3.4.1.
+2020-07-25 David Klann <dklann@linux.com>
+	* Correct the column settings in rdadmin/list_dropboxes.cpp.

--- a/ChangeLog
+++ b/ChangeLog
@@ -19922,3 +19922,5 @@
 	* Incremented the package version to 3.4.1.
 2020-07-25 David Klann <dklann@linux.com>
 	* Correct the column settings in rdadmin/list_dropboxes.cpp.
+2020-07-31 David Klann <dklann@linux.com>
+	* Remove "Qt::AlignVCenter|" from User Defined.

--- a/rdadmin/list_dropboxes.cpp
+++ b/rdadmin/list_dropboxes.cpp
@@ -108,7 +108,7 @@ ListDropboxes::ListDropboxes(const QString &stationname,QWidget *parent)
   list_dropboxes_view->addColumn(tr("Fix Broken Formats"));
   list_dropboxes_view->setColumnAlignment(9,Qt::AlignCenter);
   list_dropboxes_view->addColumn(tr("User Defined"));
-  list_dropboxes_view->setColumnAlignment(10,Qt::AlignVCenter|Qt::AlignLeft);
+  list_dropboxes_view->setColumnAlignment(10,Qt::AlignLeft);
   connect(list_dropboxes_view,
 	  SIGNAL(doubleClicked(Q3ListViewItem *,const QPoint &,int)),
 	  this,

--- a/rdadmin/list_dropboxes.cpp
+++ b/rdadmin/list_dropboxes.cpp
@@ -88,27 +88,27 @@ ListDropboxes::ListDropboxes(const QString &stationname,QWidget *parent)
   list_dropboxes_view=new RDListView(this);
   list_dropboxes_view->setAllColumnsShowFocus(true);
   list_dropboxes_view->addColumn(tr("ID"));
-  list_dropboxes_view->setColumnAlignment(0,Qt::AlignVCenter|Qt::AlignRight);
+  list_dropboxes_view->setColumnAlignment(0,Qt::AlignRight);
   list_dropboxes_view->addColumn(tr("Group"));
-  list_dropboxes_view->setColumnAlignment(0,Qt::AlignVCenter|Qt::AlignLeft);
+  list_dropboxes_view->setColumnAlignment(1,Qt::AlignLeft);
   list_dropboxes_view->addColumn(tr("Path"));
-  list_dropboxes_view->setColumnAlignment(1,Qt::AlignVCenter|Qt::AlignLeft);
+  list_dropboxes_view->setColumnAlignment(2,Qt::AlignLeft);
   list_dropboxes_view->addColumn(tr("Normalization Level"));
-  list_dropboxes_view->setColumnAlignment(2,Qt::AlignCenter);
-  list_dropboxes_view->addColumn(tr("Autotrim Level"));
   list_dropboxes_view->setColumnAlignment(3,Qt::AlignCenter);
-  list_dropboxes_view->addColumn(tr("To Cart"));
+  list_dropboxes_view->addColumn(tr("Autotrim Level"));
   list_dropboxes_view->setColumnAlignment(4,Qt::AlignCenter);
-  list_dropboxes_view->addColumn(tr("Use CartChunk ID"));
+  list_dropboxes_view->addColumn(tr("To Cart"));
   list_dropboxes_view->setColumnAlignment(5,Qt::AlignCenter);
-  list_dropboxes_view->addColumn(tr("Delete Cuts"));
+  list_dropboxes_view->addColumn(tr("Use CartChunk ID"));
   list_dropboxes_view->setColumnAlignment(6,Qt::AlignCenter);
-  list_dropboxes_view->addColumn(tr("Metadata Pattern"));
+  list_dropboxes_view->addColumn(tr("Delete Cuts"));
   list_dropboxes_view->setColumnAlignment(7,Qt::AlignCenter);
-  list_dropboxes_view->addColumn(tr("Fix Broken Formats"));
+  list_dropboxes_view->addColumn(tr("Metadata Pattern"));
   list_dropboxes_view->setColumnAlignment(8,Qt::AlignCenter);
+  list_dropboxes_view->addColumn(tr("Fix Broken Formats"));
+  list_dropboxes_view->setColumnAlignment(9,Qt::AlignCenter);
   list_dropboxes_view->addColumn(tr("User Defined"));
-  list_dropboxes_view->setColumnAlignment(9,Qt::AlignVCenter|Qt::AlignLeft);
+  list_dropboxes_view->setColumnAlignment(10,Qt::AlignVCenter|Qt::AlignLeft);
   connect(list_dropboxes_view,
 	  SIGNAL(doubleClicked(Q3ListViewItem *,const QPoint &,int)),
 	  this,


### PR DESCRIPTION
It seems as if this has been broken for a long time. The values in the Path column has been centered for as long as I can recall. I finally looked at the code and the column numbers included two references to column Zero (0).

Also, I compiled the code with `Qt::AlignVCenter` OR'd in and it didn't seem to obey horizontal alignment. DId I do it wrong?

Thanks for considering this PR!
