### PR TITLE
Add support for FTPS upload and download in RDCatch.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -19920,3 +19920,5 @@
 	* Incremented the package version to 3.4.0int1.
 2020-07-21 Fred Gleason <fredg@paravelsystems.com>
 	* Incremented the package version to 3.4.1.
+2020-08-03 David Klann <dklann@linux.com>
+	* Add support for SSL-encrypted FTP (FTPS).

--- a/rdcatch/edit_download.cpp
+++ b/rdcatch/edit_download.cpp
@@ -433,7 +433,7 @@ void EditDownload::urlChangedData(const QString &str)
 {
   QUrl url(str);
   QString protocol=url.protocol();
-  if((protocol=="ftp")||(protocol=="http")||(protocol=="file")||
+  if((protocol=="ftp")||(protocol=="ftps")||(protocol=="http")||(protocol=="file")||
      (protocol=="scp")||(protocol=="sftp")) {
     edit_username_label->setEnabled(true);
     edit_username_edit->setEnabled(true);
@@ -502,7 +502,7 @@ void EditDownload::okData()
   }
   QUrl url(edit_url_edit->text());
   QString protocol=url.protocol();
-  if((protocol!="ftp")&&(protocol!="http")&&(protocol!="https")&&
+  if((protocol!="ftp")&&(protocol!="ftps")&&(protocol!="http")&&(protocol!="https")&&
      (protocol!="file")&&(protocol!="scp")&&(protocol!="sftp")) {
     QMessageBox::warning(this,
 			 tr("Invalid URL"),tr("Unsupported URL protocol!"));

--- a/rdcatch/edit_upload.cpp
+++ b/rdcatch/edit_upload.cpp
@@ -449,7 +449,7 @@ void EditUpload::urlChangedData(const QString &str)
 {
   QUrl url(str);
   QString protocol=url.protocol().lower();
-  if((protocol=="ftp")||(protocol=="file")||
+  if((protocol=="ftp")||(protocol=="ftps")||(protocol=="file")||
      (protocol=="scp")||(protocol=="sftp")) {
     edit_username_label->setEnabled(true);
     edit_username_edit->setEnabled(true);
@@ -527,7 +527,7 @@ void EditUpload::okData()
   }
   QUrl url(edit_url_edit->text());
   QString protocol=url.protocol();
-  if((protocol!="ftp")&&(protocol!="file")&&
+  if((protocol!="ftp")&&(protocol!="ftps")&&(protocol!="file")&&
      (protocol!="scp")&&(protocol!="sftp")) {
     QMessageBox::warning(this,
 			 tr("Invalid URL"),tr("Unsupported URL protocol!"));


### PR DESCRIPTION
cURL supports '`ftps://`' URLs so this change was trivial. I don't have easy access to an FTP site configured with SSL, so was not able to test, but downloads work consistently.