### PR TITLE
Add support for FTPS upload and download in RDCatch.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -20244,3 +20244,6 @@
 	'Podcast Feed Item List' dialog in rdcastmanager(1).
 2020-08-13 Fred Gleason <fredg@paravelsystems.com>
 	* Added an 'RDCastManager' chapter to the Operations Guide.
+2020-08-15 David Klann <dklann@linux.com>
+	* Added support for FTPS protocol for uploading, downloading, and
+        Feed management.

--- a/lib/rddelete.cpp
+++ b/lib/rddelete.cpp
@@ -81,6 +81,7 @@ QStringList RDDelete::supportedSchemes() const
   schemes.push_back("file");
   schemes.push_back("ftp");
   schemes.push_back("sftp");
+  schemes.push_back("ftps");
 
   return schemes;
 }
@@ -131,7 +132,7 @@ RDDelete::ErrorCode RDDelete::runDelete(const QString &username,
     curl_easy_setopt(curl,CURLOPT_DEBUGFUNCTION,DeleteErrorCallback);
   }
 
-  if(conv_target_url.scheme().toLower()=="ftp") {
+  if(conv_target_url.scheme().toLower()=="ftp"||conv_target_url.scheme().toLower()=="ftps") {
     QStringList f0=conv_target_url.path().split("/",QString::SkipEmptyParts);
     filename=f0.last();
     f0.removeLast();

--- a/lib/rddownload.cpp
+++ b/lib/rddownload.cpp
@@ -82,6 +82,7 @@ QStringList RDDownload::supportedSchemes() const
 
   schemes.push_back("file");
   schemes.push_back("ftp");
+  schemes.push_back("ftps");
   schemes.push_back("http");
   schemes.push_back("https");
   schemes.push_back("sftp");

--- a/lib/rdupload.cpp
+++ b/lib/rdupload.cpp
@@ -85,6 +85,7 @@ QStringList RDUpload::supportedSchemes() const
   schemes.push_back("file");
   schemes.push_back("ftp");
   schemes.push_back("sftp");
+  schemes.push_back("ftps");
 
   return schemes;
 }

--- a/rdcatch/edit_download.cpp
+++ b/rdcatch/edit_download.cpp
@@ -433,7 +433,7 @@ void EditDownload::urlChangedData(const QString &str)
 {
   QUrl url(str);
   QString protocol=url.protocol();
-  if((protocol=="ftp")||(protocol=="http")||(protocol=="file")||
+  if((protocol=="ftp")||(protocol=="ftps")||(protocol=="http")||(protocol=="file")||
      (protocol=="scp")||(protocol=="sftp")) {
     edit_username_label->setEnabled(true);
     edit_username_edit->setEnabled(true);
@@ -502,7 +502,7 @@ void EditDownload::okData()
   }
   QUrl url(edit_url_edit->text());
   QString protocol=url.protocol();
-  if((protocol!="ftp")&&(protocol!="http")&&(protocol!="https")&&
+  if((protocol!="ftp")&&(protocol!="ftps")&&(protocol!="http")&&(protocol!="https")&&
      (protocol!="file")&&(protocol!="scp")&&(protocol!="sftp")) {
     QMessageBox::warning(this,
 			 tr("Invalid URL"),tr("Unsupported URL protocol!"));

--- a/rdcatch/edit_upload.cpp
+++ b/rdcatch/edit_upload.cpp
@@ -449,7 +449,7 @@ void EditUpload::urlChangedData(const QString &str)
 {
   QUrl url(str);
   QString protocol=url.protocol().lower();
-  if((protocol=="ftp")||(protocol=="file")||
+  if((protocol=="ftp")||(protocol=="ftps")||(protocol=="file")||
      (protocol=="scp")||(protocol=="sftp")) {
     edit_username_label->setEnabled(true);
     edit_username_edit->setEnabled(true);
@@ -527,7 +527,7 @@ void EditUpload::okData()
   }
   QUrl url(edit_url_edit->text());
   QString protocol=url.protocol();
-  if((protocol!="ftp")&&(protocol!="file")&&
+  if((protocol!="ftp")&&(protocol!="ftps")&&(protocol!="file")&&
      (protocol!="scp")&&(protocol!="sftp")) {
     QMessageBox::warning(this,
 			 tr("Invalid URL"),tr("Unsupported URL protocol!"));


### PR DESCRIPTION
cURL supports 'ftps://' URLs so this change was trivial.

I have tested FTPS download (`rdcatch`), upload (`rdcastmanager`), and delete (rdcastmanger`). All are working with the FTPS server at nxx.grunch.org. FTP server log available on request...