### PR TITLE
Fixed title separation in rdlogmanager(1) scheduler.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -20686,3 +20686,7 @@
 	* Incremented the package version to 3.4.1int9.
 2020-12-12 Fred Gleason <fredg@paravelsystems.com>
 	* Incremented the package version to 3.5.0.
+2020-12-22 Patrick Linstruth <patrick@deltecent.com>
+	* Fixed title separation in rdlogmanager(1) scheduler.
+	* Added a 'STACK_LINES.TITLE' field to the database.
+	* Incremented the database version to 347.

--- a/docs/tables/stack_lines.txt
+++ b/docs/tables/stack_lines.txt
@@ -9,4 +9,5 @@ SCHED_STACK_ID       int(10) unsigned
 SERVICE_NAME         varchar(10)        From SERVICES.NAME
 CART                 int(10) unsigned   From CART.NUMBER
 ARTIST               varchar(191)       From CART.ARTIST
+TITLE                varchar(191)       From CART.TITLE
 SCHEDULED_AT         datetime

--- a/lib/dbversion.h
+++ b/lib/dbversion.h
@@ -24,7 +24,7 @@
 /*
  * Current Database Version
  */
-#define RD_VERSION_DATABASE 346
+#define RD_VERSION_DATABASE 347
 
 
 #endif  // DBVERSION_H

--- a/lib/rdschedcartlist.cpp
+++ b/lib/rdschedcartlist.cpp
@@ -29,12 +29,14 @@ RDSchedCartList::RDSchedCartList()
 
 void RDSchedCartList::insertItem(unsigned cartnumber,int cartlength,int stack_id,
 			       const QString &stack_artist,
+			       const QString &stack_title,
 			       const QStringList &stack_schedcodes)
 {
   list_cartnum.push_back(cartnumber);
   list_cartlen.push_back(cartlength);
   list_stackid.push_back(stack_id);
   list_artist.push_back(stack_artist.lower().replace(" ",""));
+  list_title.push_back(stack_title.lower().replace(" ",""));
   list_schedcodes.push_back(stack_schedcodes);  
 }
 
@@ -45,6 +47,7 @@ void RDSchedCartList::removeItem(int itemnumber)
   list_cartlen.removeAt(itemnumber);
   list_stackid.removeAt(itemnumber);
   list_artist.removeAt(itemnumber);
+  list_title.removeAt(itemnumber);
   list_schedcodes.removeAt(itemnumber);
 }
 
@@ -58,6 +61,7 @@ bool RDSchedCartList::removeIfCode(int itemnumber,const QString &test_code)
       list_cartlen.removeAt(i);
       list_stackid.removeAt(i);
       list_artist.removeAt(i);
+      list_title.removeAt(i);
       list_schedcodes.removeAt(i);
       matched=true;
     }
@@ -91,6 +95,7 @@ void RDSchedCartList::save(void)
   list_savecartlen=list_cartlen;
   list_savestackid=list_stackid;
   list_saveartist=list_artist;
+  list_savetitle=list_title;
   list_saveschedcodes=list_schedcodes;
 }
 
@@ -101,6 +106,7 @@ void RDSchedCartList::restore(void)
   list_cartlen=list_savecartlen;
   list_stackid=list_savestackid;
   list_artist=list_saveartist;
+  list_title=list_savetitle;
   list_schedcodes=list_saveschedcodes;
 }
 
@@ -120,6 +126,12 @@ int RDSchedCartList::getItemStackid(int itemnumber)
 QString RDSchedCartList::getItemArtist(int itemnumber)
 {
   return list_artist.at(itemnumber);
+}
+
+
+QString RDSchedCartList::getItemTitle(int itemnumber)
+{
+  return list_title.at(itemnumber);
 }
 
 

--- a/lib/rdschedcartlist.h
+++ b/lib/rdschedcartlist.h
@@ -31,6 +31,7 @@ class RDSchedCartList
    RDSchedCartList();
    void insertItem(unsigned cartnumber,int cartlength,int stack_id,
 		   const QString &stack_artist,
+	           const QString &stack_title,
 		   const QStringList &stack_schedcodes);
    void removeItem(int itemnumber);
    bool removeIfCode(int itemnumber,const QString &test_code);
@@ -40,6 +41,7 @@ class RDSchedCartList
    int getItemCartLength(int itemnumber);
    int getItemStackid(int itemnumber);
    QString getItemArtist(int itemnumber);
+   QString getItemTitle(int itemnumber);
    QStringList getItemSchedCodes(int itemnumber);
    int getNumberOfItems(void);
    void save(void);
@@ -53,7 +55,9 @@ class RDSchedCartList
    QList<int> list_stackid;
    QList<int> list_savestackid;
    QStringList list_artist;
+   QStringList list_title;
    QStringList list_saveartist;
+   QStringList list_savetitle;
    QList<QStringList> list_schedcodes;
    QList<QStringList> list_saveschedcodes;
 };

--- a/utils/rddbmgr/rddbmgr.h
+++ b/utils/rddbmgr/rddbmgr.h
@@ -105,6 +105,7 @@ class MainObject : public QObject
   bool ConvertTimeField186(const QString &table,const QString &field,
 			   QString *err_msg) const;
   bool ConvertArtistSep307(QString *err_msg) const;
+  bool StackLineTitles347(QString *err_msg) const;
 
   //
   // revertschema.cpp

--- a/utils/rddbmgr/revertschema.cpp
+++ b/utils/rddbmgr/revertschema.cpp
@@ -41,6 +41,15 @@ bool MainObject::RevertSchema(int cur_schema,int set_schema,QString *err_msg)
 
 
   //
+  // Revert 347
+  //
+  if((cur_schema==347)&&(set_schema<cur_schema)) {
+    DropColumn("STACK_LINES","TITLE");
+
+    WriteSchemaVersion(--cur_schema);
+  }
+
+  //
   // Revert 346
   //
   if((cur_schema==346)&&(set_schema<cur_schema)) {

--- a/utils/rddbmgr/schemamap.cpp
+++ b/utils/rddbmgr/schemamap.cpp
@@ -161,7 +161,7 @@ void MainObject::InitializeSchemaMap() {
   global_version_map["3.2"]=311;
   global_version_map["3.3"]=314;
   global_version_map["3.4"]=317;
-  global_version_map["3.5"]=346;
+  global_version_map["3.5"]=347;
 }
 
 


### PR DESCRIPTION
Added a 'STACK_LINES.TITLE' field to the database.
Incremented the database version to 347.

Fixes #634 