### PR TITLE
Be less 'greedy' copying CartChunk Cut ID data.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -54,3 +54,6 @@ Chris Smowton
 Scott Spillers <scotts@paravelsystems.com>
    The original Icon set
 
+David Klann <dklann@broadcasttool.com>
+   Some small bug fixes
+

--- a/ChangeLog
+++ b/ChangeLog
@@ -20702,3 +20702,6 @@
 2020-12-24 Fred Gleason <fredg@paravelsystems.com>
 	* Modified the schema map in rddbmgr(8) to position schema update
 	347 as part of v3.6.x.
+2021-01-17 David Klann <dklann@broadcasttool.com>
+	* Fixed bug in lib/rdwavefile.cpp that copied CartChunk Cut ID
+	past the end of the first "NULL" character.

--- a/lib/rdwavefile.cpp
+++ b/lib/rdwavefile.cpp
@@ -4644,6 +4644,7 @@ QString RDWaveFile::cutString(char *buffer,unsigned start_point,unsigned size)
   QString string;
 
   for(unsigned i=start_point;i<start_point+size;i++) {
+    if(!(buffer[i])) break;
     string=string.append(buffer[i]);
   }
   


### PR DESCRIPTION
QStrings, like C strings end with "0", so
stop when reaching the first instance of 0.

fixes #636 

Signed-off-by: David Klann <dklann@broadcasttool.com>