### PR TITLE
VU Meters update.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -20739,3 +20739,7 @@
 2021-04-08 Fred Gleason <fredg@paravelsystems.com>
 	* Fixed a bug in 'RDFlacDecode' that caused conversion of files
 	with names containing non-ASCII characters to fail.
+2021-04-12 David Klann <dklann@broadcasttool.com>
+	* Changed the way in which the VU Meter UDP port is chosen. One
+	can now specify the base port number and the maximum number of UDP
+	ports to consider when caed(8) sets up the VU meter port.

--- a/conf/rd.conf-sample
+++ b/conf/rd.conf-sample
@@ -164,3 +164,15 @@ TranscodingDelay=0
 
 ; Lock memory in RDAirPlay
 ; LockRdairplayMemory=Yes
+
+; Number at which to start looking for available UDP ports for VU
+; meters. You should only change this if you have another service
+; using UDP Port numbers in the range MeterPortBaseNumber to
+; (MeterPortBaseNumber + MeterPortRange) (extremely rare).
+; MeterPortBaseNumber=30000
+
+; Maximum number of UDP Ports to consider for VU meters. You may need
+; to change this if you have many (say, more than 80) Rivendell
+; dropboxes configured. Rivendell imposes a hard limit of 999 on this
+; setting.
+; MeterPortRange=100

--- a/lib/rd.h
+++ b/lib/rd.h
@@ -625,4 +625,16 @@
  */
 #define RD_GPIO_EVENT_DAYS 30
 
+/*
+ * Starting UDP port for cae_meter_socket.
+ * Default 'MeterPortBaseNumber=' value in rd.conf(5)
+ */
+#define RD_DEFAULT_METER_SOCKET_BASE_UDP_PORT 30000
+
+/*
+ * Maximum number of UDP ports to consider for cae_meter_socket.
+ * Default 'MeterPortRange' value in rd.conf(5)
+ */
+#define RD_METER_SOCKET_PORT_RANGE 100
+
 #endif  // RD_H

--- a/lib/rdcae.cpp
+++ b/lib/rdcae.cpp
@@ -56,9 +56,14 @@ RDCae::RDCae(RDStation *station,RDConfig *config,QObject *parent)
   //
   cae_meter_socket=new Q3SocketDevice(Q3SocketDevice::Datagram);
   cae_meter_socket->setBlocking(false);
-  for(Q_INT16 i=30000;i<30100;i++) {
+  cae_meter_base_port=cae_config->meterBasePort();
+  cae_meter_port_range=cae_config->meterPortRange();
+  if(cae_meter_port_range>999) {
+    cae_meter_port_range=999;
+  }
+  for(Q_INT16 i=cae_meter_base_port;i<(cae_meter_base_port+cae_meter_port_range);i++) {
     if(cae_meter_socket->bind(QHostAddress(),i)) {
-      i=31000;
+      i=(cae_meter_base_port+cae_meter_port_range)+1;
     }
   }
 

--- a/lib/rdcae.h
+++ b/lib/rdcae.h
@@ -113,6 +113,8 @@ class RDCae : public QObject
   int cae_handle[RD_MAX_CARDS][RD_MAX_STREAMS];
   unsigned cae_pos[RD_MAX_CARDS][RD_MAX_STREAMS];
   Q3SocketDevice *cae_meter_socket;
+  int cae_meter_base_port;
+  int cae_meter_port_range;
   short cae_input_levels[RD_MAX_CARDS][RD_MAX_PORTS][2];
   short cae_output_levels[RD_MAX_CARDS][RD_MAX_PORTS][2];
   short cae_stream_output_levels[RD_MAX_CARDS][RD_MAX_PORTS][2];

--- a/lib/rdconfig.cpp
+++ b/lib/rdconfig.cpp
@@ -382,6 +382,18 @@ bool RDConfig::lockRdairplayMemory() const
 }
 
 
+int RDConfig::meterBasePort() const
+{
+  return conf_meter_base_port;
+}
+
+
+int RDConfig::meterPortRange() const
+{
+  return conf_meter_port_range;
+}
+
+
 uid_t RDConfig::uid() const
 {
   return conf_uid;
@@ -590,6 +602,10 @@ bool RDConfig::load()
     profile->boolValue("Hacks","DisableMaintChecks",false);
   conf_lock_rdairplay_memory=
     profile->boolValue("Hacks","LockRdairplayMemory",false);
+  conf_meter_base_port=
+    profile->intValue("Hacks","MeterPortBaseNumber",RD_DEFAULT_METER_SOCKET_BASE_UDP_PORT);
+  conf_meter_port_range=
+    profile->intValue("Hacks","MeterPortRange",RD_METER_SOCKET_PORT_RANGE);
   if((user=getpwnam(profile->stringValue("Identity","AudioOwner")))!=NULL) {
     conf_uid=user->pw_uid;
   }
@@ -713,6 +729,8 @@ void RDConfig::clear()
   conf_jack_ports[1].clear();
   conf_disable_maint_checks=false;
   conf_lock_rdairplay_memory=false;
+  conf_meter_base_port=RD_DEFAULT_METER_SOCKET_BASE_UDP_PORT;
+  conf_meter_port_range=RD_METER_SOCKET_PORT_RANGE;
   conf_uid=65535;
   conf_gid=65535;
   conf_pypad_uid=65535;

--- a/lib/rdconfig.h
+++ b/lib/rdconfig.h
@@ -100,6 +100,8 @@ class RDConfig
   QString jackPort(int num,int endpt) const;
   bool disableMaintChecks() const;
   bool lockRdairplayMemory() const;
+  int meterBasePort() const;
+  int meterPortRange() const;
   bool enableMixerLogging() const;
   uid_t uid() const;
   gid_t gid() const;
@@ -170,6 +172,8 @@ class RDConfig
   QString conf_http_user_agent;
   bool conf_disable_maint_checks;
   bool conf_lock_rdairplay_memory;
+  int conf_meter_base_port;
+  int conf_meter_port_range;
   std::vector<QString> conf_jack_ports[2];
   uid_t conf_uid;
   gid_t conf_gid;

--- a/systemd/rivendell.service.in
+++ b/systemd/rivendell.service.in
@@ -3,6 +3,7 @@ Description=Rivendell Radio Automation System
 After=network.target remote-fs.target nss-lookup.target
 
 [Service]
+LimitNOFILE=4096
 Type=simple
 ExecStart=@prefix@/sbin/rdservice
 PrivateTmp=false


### PR DESCRIPTION
Parameterize values used for allocating the UDP port number for VU meters.

Fixes Issue #650 

Signed-off-by: David Klann <dklann@broadcasttool.com>