### PR TITLE
Fix drawWaveByMsecs when startmsecs or endmsecs are negative

### DIFF
--- a/lib/rdwavepainter.cpp
+++ b/lib/rdwavepainter.cpp
@@ -221,8 +221,8 @@ void RDWavePainter::drawWaveByMsecs(int x,int w,int startmsecs,int endmsecs,
 				    int startclip,int endclip)
 {
   drawWaveBySamples(x,w,
-	     (unsigned)((double)startmsecs*(double)wave_sample_rate/1000.0),
-	     (unsigned)((double)endmsecs*(double)wave_sample_rate/1000.0),
+	     (int)((double)startmsecs*(double)wave_sample_rate/1000.0),
+	     (int)((double)endmsecs*(double)wave_sample_rate/1000.0),
 	     gain,channel,color,
 	     (int)((double)startclip*(double)wave_sample_rate/1000.0),
 	     (int)((double)endclip*(double)wave_sample_rate/1000.0));


### PR DESCRIPTION
On ARM, the unsigned cast seems to be respected; on x64, apparently not. 

In RDLogEdit's Voice Tracker, this causes incorrect waveform display on ARM systems (https://github.com/ElvishArtisan/rivendell/issues/389) - `startmsecs` can be negative when the start of the clip is to the right of X=0 (normal for the middle and bottom tracks).