### PR TITLE
Fix parsing of macros that contain NN as well as other commands

### DIFF
--- a/lib/rdmacro_event.cpp
+++ b/lib/rdmacro_event.cpp
@@ -112,15 +112,16 @@ bool RDMacroEvent::load(const QString &str)
 {
   RDMacro cmd;
   QString rmlstr="";
-
+  bool onlynull = true;
   for(int i=0;i<str.length();i++) {
     QChar c=str.at(i);
     rmlstr+=c;
     if(c=='!') {
       cmd=RDMacro::fromString(rmlstr,RDMacro::Cmd);
       if(cmd.isNull()) {
-	clear();
-	return false;
+        continue;
+      } else {
+        onlynull = false;
       }
       cmd.setAddress(event_address);
       cmd.setEchoRequested(false);
@@ -128,7 +129,12 @@ bool RDMacroEvent::load(const QString &str)
       rmlstr="";
     }
   }
-  return true;
+  if (onlynull) {
+    clear();
+    return false;
+  } else {
+    return true;
+  }
 }
 
 


### PR DESCRIPTION
If a macro contains an `NN` command as well as others, since 26c29e1d4ed8cb228e6c46716393ee17db804ce2, that macro would be parsed as null by `RDMacroEvent::load`.

This PR ignores any null commands within a macro (is that the right behaviour or should they be preserved?), but tracks whether the macro contains _only_ null commands. If so, it clears and returns false as before. Where the macro contains other commands as well as the `NN`, the other commands are loaded correctly, and only the `NN` is ignored.

To reproduce:
- Create a new macro cart in `RDLibrary`
- Add one regular line, like `PN 1!`
- Add a second line, `NN !` (the default value if you double-click `--- End of cart ---` and click OK)
- Save the cart
- Edit the cart again

Expected behaviour: at least `PN 1!` is still visible; executing macro works.
Behaviour in v3.6.2: no lines (except `--- End of cart---`) are visible, and macro will not execute.