### PR TITLE
RDLogManager: Imported cart transition type should still be enabled when selecting from a group

### DIFF
--- a/rdlogmanager/edit_event.cpp
+++ b/rdlogmanager/edit_event.cpp
@@ -1059,7 +1059,6 @@ void EditEvent::importClickedData(int id)
     statesched=false;
   }
   if(id==3) {
-    state=false;
     statesched=false;
     stateschedinv=true;
   }


### PR DESCRIPTION
In RDLogManager's event editor, when the `IMPORT: Select from: <group name>` option is chosen, the `TRANSITIONS: Imported carts have a <type> transition` controls are disabled:
![image](https://user-images.githubusercontent.com/809741/140798356-0fe6ab19-befc-41a4-842c-1296284776fb.png)

The value of that control is still honoured: changing to `IMPORT: From Music`, editing the transition type to segue, then changing back to `IMPORT: Select from: <group name>` does the right thing.

This PR allows the controls to remain enabled when that option is active.