### PR TITLE
Support selection of cuts that have a start, but no end, date

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -20959,3 +20959,5 @@
 	of the 'direct' name space.
 2022-11-21 Fred Gleason <fredg@paravelsystems.com>
 	* Incremented the package version to 3.6.6int0.
+2022-12-15 Robert Chipperfield <robert@syxis.co.uk>
+	* Supported selection of cuts that have a start, but no end date

--- a/lib/rdcart.cpp
+++ b/lib/rdcart.cpp
@@ -117,9 +117,8 @@ bool RDCart::selectCut(QString *cut,const QTime &time) const
       "LOCAL_COUNTER,"+
       "LAST_PLAY_DATETIME "+
       "from CUTS  where ("+
-      "((START_DATETIME<=\""+datetime_str+"\")&&"+
-      "(END_DATETIME>=\""+datetime_str+"\"))||"+
-      "(START_DATETIME is null))&&"+
+      "(START_DATETIME is null || START_DATETIME<=\""+datetime_str+"\")&&"+
+      "(END_DATETIME is null || END_DATETIME>=\""+datetime_str+"\"))&&"+
       "(((START_DAYPART<=\""+time_str+"\")&&"+
       "(END_DAYPART>=\""+time_str+"\")||"+
       "START_DAYPART is null))&&"+


### PR DESCRIPTION
Previously, a cut that had no start date would be selected (regardless of its end date); one that had a start date but null end date would not. 

This considers null start and end dates to be infinitely far in the past and future respectively.