### PR TITLE
Fix undefined symbol when using ProcessNullUpdates in configuration file

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -54,3 +54,5 @@ Chris Smowton
 Scott Spillers <scotts@paravelsystems.com>
    The original Icon set
 
+Florent Peyraud <florent@draceo.fr>
+   Pypad fix

--- a/ChangeLog
+++ b/ChangeLog
@@ -23846,3 +23846,5 @@
 	rddbmgr(8).
 2022-12-21 Fred Gleason <fredg@paravelsystems.com>
 	* Incremented the package version to 4.0.0rc0int11.
+2022-12-23 Florent Peyraud <florent@draceo.fr>
+	* Fix pypad lib which crashed when ProcessNullUpdates!=0 in conffile

--- a/apis/pypad/api/pypad.py
+++ b/apis/pypad/api/pypad.py
@@ -725,11 +725,11 @@ class Update(object):
                 if self.__config.get(section,'ProcessNullUpdates')=='0':
                     result=result and True
                 if self.__config.get(section,'ProcessNullUpdates')=='1':
-                    result=result and self.hasPadType(pypad.TYPE_NOW)
+                    result=result and self.hasPadType(TYPE_NOW)
                 if self.__config.get(section,'ProcessNullUpdates')=='2':
-                    result=result and self.hasPadType(pypad.TYPE_NEXT)
+                    result=result and self.hasPadType(TYPE_NEXT)
                 if self.__config.get(section,'ProcessNullUpdates')=='3':
-                    result=result and self.hasPadType(pypad.TYPE_NOW) and self.hasPadType(pypad.TYPE_NEXT)
+                    result=result and self.hasPadType(TYPE_NOW) and self.hasPadType(TYPE_NEXT)
             else:
                 result=result and True
 


### PR DESCRIPTION
Hello
When using pypad_udp.py, the pypad instance crashed complaining about undefined pypad object. This pull requests fixes this issue
Regards
Florent