### PR TITLE
Fix QT compile-time warnings

### DIFF
--- a/lib/export_resultsrecon.cpp
+++ b/lib/export_resultsrecon.cpp
@@ -86,7 +86,7 @@ bool RDReport::ExportResultsReport(const QString &filename,
 
     // Title / Artist
     *strm << QString().
-      sprintf("\"%-23s  %-25s\",",
+      asprintf("\"%-23s  %-25s\",",
 	      q->value(5).toString().left(23).toUtf8().constData(),
 	      q->value(6).toString().left(25).toUtf8().constData());
 

--- a/lib/export_resultsrecon.cpp
+++ b/lib/export_resultsrecon.cpp
@@ -85,8 +85,7 @@ bool RDReport::ExportResultsReport(const QString &filename,
     *strm << QString::asprintf("%03d,",q->value(4).toInt());
 
     // Title / Artist
-    *strm << QString().
-      asprintf("\"%-23s  %-25s\",",
+    *strm << QString::asprintf("\"%-23s  %-25s\",",
 	      q->value(5).toString().left(23).toUtf8().constData(),
 	      q->value(6).toString().left(25).toUtf8().constData());
 

--- a/lib/rdbusybar.h
+++ b/lib/rdbusybar.h
@@ -32,7 +32,7 @@ class RDBusyBar : public QFrame
   Q_OBJECT
 
  public:
-  RDBusyBar(QWidget *parent=0,Qt::WindowFlags f=0);
+  RDBusyBar(QWidget *parent=0,Qt::WindowFlags f=Qt::WindowFlags());
 
  public slots:
   void activate(bool state);

--- a/lib/rdbusydialog.h
+++ b/lib/rdbusydialog.h
@@ -28,7 +28,7 @@ class RDBusyDialog : public RDDialog
 {
   Q_OBJECT;
  public:
-  RDBusyDialog(QWidget *parent=0,Qt::WindowFlags f=0);
+  RDBusyDialog(QWidget *parent=0,Qt::WindowFlags f=Qt::WindowFlags());
   ~RDBusyDialog();
   QSize sizeHint() const;
   void show(const QString &caption,const QString &label);

--- a/lib/rddialog.h
+++ b/lib/rddialog.h
@@ -29,8 +29,8 @@ class RDDialog : public QDialog, public RDFontEngine
 {
   Q_OBJECT;
  public:
-  RDDialog(QWidget *parent=0,Qt::WindowFlags f=0);
-  RDDialog(RDConfig *config,QWidget *parent=0,Qt::WindowFlags f=0);
+  RDDialog(QWidget *parent=0,Qt::WindowFlags f=Qt::WindowFlags());
+  RDDialog(RDConfig *config,QWidget *parent=0,Qt::WindowFlags f=Qt::WindowFlags());
 };
 
 

--- a/lib/rdframe.h
+++ b/lib/rdframe.h
@@ -29,8 +29,8 @@ class RDFrame : public QFrame, public RDFontEngine
 {
   Q_OBJECT;
  public:
-  RDFrame(QWidget *parent=0,Qt::WindowFlags f=0);
-  RDFrame(RDConfig *config,QWidget *parent=0,Qt::WindowFlags f=0);
+  RDFrame(QWidget *parent=0,Qt::WindowFlags f=Qt::WindowFlags());
+  RDFrame(RDConfig *config,QWidget *parent=0,Qt::WindowFlags f=Qt::WindowFlags());
 };
 
 

--- a/lib/rdmainwindow.h
+++ b/lib/rdmainwindow.h
@@ -34,8 +34,8 @@ class RDMainWindow : public RDWidget
 {
   Q_OBJECT;
  public:
-  RDMainWindow(const QString &cmdname,Qt::WindowFlags f=0);
-  RDMainWindow(const QString &cmdname,RDConfig *c,Qt::WindowFlags f=0);
+  RDMainWindow(const QString &cmdname,Qt::WindowFlags f=Qt::WindowFlags());
+  RDMainWindow(const QString &cmdname,RDConfig *c,Qt::WindowFlags f=Qt::WindowFlags());
   ~RDMainWindow();
   bool loadSettings(bool apply_geometry);
   bool saveSettings() const;

--- a/lib/rdtimeedit.cpp
+++ b/lib/rdtimeedit.cpp
@@ -206,7 +206,7 @@ void RDTimeEdit::stepBy(int steps)
       d_step_enabled=QTimeEdit::stepEnabled();
     }
     else {
-      d_step_enabled=0;
+      d_step_enabled=StepNone;
       if(tenths>tenths_lo_limit) {
 	d_step_enabled=d_step_enabled|StepDownEnabled;
       }

--- a/lib/rdtimeedit.cpp
+++ b/lib/rdtimeedit.cpp
@@ -136,7 +136,7 @@ void RDTimeEdit::fixup(QString &input) const
   // Don't allow higher precision than tenths of a second
   //
   if(d_show_tenths) {
-    QStringList f0=input.split(".",QString::KeepEmptyParts);
+    QStringList f0=input.split(".",Qt::KeepEmptyParts);
     if(f0.size()==2) {
       QStringList f1=f0.at(1).split(" ");
       if(f1.at(0).length()>1) {

--- a/lib/rdwidget.h
+++ b/lib/rdwidget.h
@@ -29,8 +29,8 @@ class RDWidget : public QWidget, public RDFontEngine
 {
   Q_OBJECT;
  public:
-  RDWidget(QWidget *parent=0,Qt::WindowFlags f=0);
-  RDWidget(RDConfig *config,QWidget *parent=0,Qt::WindowFlags f=0);
+  RDWidget(QWidget *parent=0,Qt::WindowFlags f=Qt::WindowFlags());
+  RDWidget(RDConfig *config,QWidget *parent=0,Qt::WindowFlags f=Qt::WindowFlags());
   QPixmap backgroundPixmap() const;
   void setBackgroundPixmap(const QPixmap &pix);
 

--- a/rdcatch/vbox.h
+++ b/rdcatch/vbox.h
@@ -31,7 +31,7 @@ class VBox : public QWidget
 {
   Q_OBJECT
  public:
-  VBox(QWidget *parent=0,Qt::WindowFlags f=0);
+  VBox(QWidget *parent=0,Qt::WindowFlags f=Qt::WindowFlags());
   void addWidget(QWidget *widget);
   void setSpacing(int space);
 

--- a/rdlibrary/mainwindow.h
+++ b/rdlibrary/mainwindow.h
@@ -27,7 +27,7 @@ class MainWindow : public RDMainWindow
 {
   Q_OBJECT;
  public:
-  MainWindow(const QString &cmdname,RDConfig *c,Qt::WindowFlags f=0);
+  MainWindow(const QString &cmdname,RDConfig *c,Qt::WindowFlags f=Qt::WindowFlags());
   bool showNoteBubbles() const;
   void setShowNoteBubbles(bool state);
   bool dragEnabled() const;


### PR DESCRIPTION
Fixes this compile-time warning:

```
./rddialog.h:33:65: warning: ‘constexpr QFlags<T>::QFlags(QFlags<T>::Zero) [with Enum = Qt::WindowType; QFlags<T>::Zero = int QFlags<Qt::WindowType>::Private::*]’ is deprecated: Use default constructor instead [-Wdeprecated-declarations]
   33 |   RDDialog(RDConfig *config,QWidget *parent=0,Qt::WindowFlags f=0);
      |                                                                 ^
In file included from /usr/include/x86_64-linux-gnu/qt5/QtCore/qglobal.h:1299,
                 from /usr/include/x86_64-linux-gnu/qt5/QtGui/qtguiglobal.h:43,
                 from /usr/include/x86_64-linux-gnu/qt5/QtWidgets/qtwidgetsglobal.h:43,
                 from /usr/include/x86_64-linux-gnu/qt5/QtWidgets/qapplication.h:43,
                 from /usr/include/x86_64-linux-gnu/qt5/QtWidgets/QApplication:1,
                 from rdcart_dialog.cpp:24:
/usr/include/x86_64-linux-gnu/qt5/QtCore/qflags.h:123:80: note: declared here
  123 |     QT_DEPRECATED_X("Use default constructor instead") Q_DECL_CONSTEXPR inline QFlags(Zero) noexcept : i(0) {}
```
