### PR TITLE
Bug fix for rdtrackerwidget

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -9,6 +9,9 @@ Todd Baker <bakert@rfa.org>
 Luigino Bracci <lbracci@gmail.com>
    Spanish translation.
 
+Chris Conkright <cconkrig@gmail.com>
+   General bug fix
+
 Josh Edelstein <edelsteinj@rfa.org>
    Icon Set
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -24944,3 +24944,6 @@
 2024-12-13 Fred Gleason <fredg@paravelsystems.com>
 	* Fixed regression in the build system that caused sections of the
 	HTML version of Operations Guide to be missing.
+2024-12-14 Chris Conkright <cconkrig@gmail.com>
+	* Fixed a bug where Voice Tracker widget's  'Est. Time' column would
+	show scheduled time instead of estimated time.	

--- a/lib/rdtrackerwidget.cpp
+++ b/lib/rdtrackerwidget.cpp
@@ -359,6 +359,7 @@ RDTrackerWidget::RDTrackerWidget(QString *import_path,QWidget *parent)
      SLOT(selectionChangedData(const QItemSelection &,const QItemSelection &)));
   connect(rda->ripc(),SIGNAL(notificationReceived(RDNotification *)),
 	  d_log_model,SLOT(processNotification(RDNotification *)));
+  d_log_model->setStartTimeStyle(RDLogModel::Estimated);
 
   //
   // Reset Button


### PR DESCRIPTION
# Description

**Bug Fix:** Voice Tracker Widget's 'Est. Time' column was displaying Scheduled Time vs Estimated Time.

Fixes Issue #980

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
 Manual compilation of source, ran the program and verified manually that the change was effective in both rdairplay and rdlogedit.

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshot After Bug Fix

![Screenshot from 2024-12-14 20-21-33](https://github.com/user-attachments/assets/cbc9af34-b928-4db7-bd2d-56584dd7a4e5)
