### PR TITLE
Bug fix for rdairplay 'Select Log' window showing stale data.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -9,6 +9,9 @@ Todd Baker <bakert@rfa.org>
 Luigino Bracci <lbracci@gmail.com>
    Spanish translation.
 
+Chris Conkright <cconkrig@gmail.com>
+   General bug fixes.
+
 Josh Edelstein <edelsteinj@rfa.org>
    Icon Set
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -24944,3 +24944,6 @@
 2024-12-13 Fred Gleason <fredg@paravelsystems.com>
 	* Fixed regression in the build system that caused sections of the
 	HTML version of Operations Guide to be missing.
+2024-12-17 Chris Conkright <cconkrig@gmail.com>
+	* Fixed bug in RDLogListModel that would cause stale data to be
+	displayed in the rdairplay(1) 'Select Log' window.

--- a/lib/rdloglistmodel.cpp
+++ b/lib/rdloglistmodel.cpp
@@ -280,11 +280,9 @@ void RDLogListModel::refresh(const QString &logname)
 void RDLogListModel::setFilterSql(const QString &where_sql,
 				  const QString &limit_sql)
 {
-  if((d_filter_where_sql!=where_sql)||(d_filter_limit_sql!=limit_sql)) {
     updateModel(where_sql,limit_sql);
     d_filter_where_sql=where_sql;
     d_filter_limit_sql=limit_sql;
-  }
 }
 
 

--- a/rdairplay/list_logs.cpp
+++ b/rdairplay/list_logs.cpp
@@ -19,6 +19,7 @@
 //
 
 #include <QMessageBox>
+#include <QScrollBar>
 
 #include <rdadd_log.h>
 #include <rdapplication.h>
@@ -124,8 +125,10 @@ int ListLogs::exec(QString *logname,QString *svcname,RDLogLock **log_lock)
     services_list.push_back(q->value(0).toString());
   }
   delete q;
+  list_log_view->clearSelection();
   list_log_model->setFilterSql(list_filter_widget->whereSql(),
 			       list_filter_widget->limitSql());
+  list_log_view->verticalScrollBar()->setValue(0);
 
   return QDialog::exec();
 }


### PR DESCRIPTION
# Description

**Bug Fix:** rdairplay's "Select Log" window contained stale data unless service or limit was changed or rdairplay was restarted. Removed the condition check in RDLogListModel::setFilterSql to ensure the model is always updated when setFilterSql is called. Added code to clear the selection (previously selected line before window was closed) in the log view. Added code to reset the vertical scroll bar to the top position when the log list is refreshed. These items effectively reset the dialog window to the initial state when rdairplay is started. 

Fixes Issue #984

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
 Manual compilation of source, ran the program and verified manually that the change was effective in rdairplay. I even manually added a log, closed the window, left rdairplay running, modified the name of the log in database backend, opened the select log window again, and everything appears to be updated and in the correct sort order as if you relaunched rdairplay. This was tested multiple times with success.

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
