### PR TITLE
Bug fix for dock icons not appearing in Ubuntu 24.04

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -24944,3 +24944,6 @@
 2024-12-13 Fred Gleason <fredg@paravelsystems.com>
 	* Fixed regression in the build system that caused sections of the
 	HTML version of Operations Guide to be missing.
+2024-12-17 Chris Conkright <cconkrig@gmail.com>
+	* Fixed dock icons in Ubuntu 24.04
+	

--- a/xdg/rivendell-rdadmin.desktop
+++ b/xdg/rivendell-rdadmin.desktop
@@ -8,3 +8,4 @@ Exec=rdadmin
 Icon=rdadmin
 Type=Application
 Terminal=false
+StartupWMClass=rdadmin

--- a/xdg/rivendell-rdairplay.desktop
+++ b/xdg/rivendell-rdairplay.desktop
@@ -7,3 +7,4 @@ Name=RDAirPlay
 GenericName=Rivendell On-Air Playout
 Exec=rdairplay
 Icon=rdairplay
+StartupWMClass=rdairplay

--- a/xdg/rivendell-rdalsaconfig-root.desktop
+++ b/xdg/rivendell-rdalsaconfig-root.desktop
@@ -8,3 +8,4 @@ Exec=rdalsaconfig-root --manage-daemons
 Icon=rivendell
 Type=Application
 Terminal=false
+StartupWMClass=rivendell

--- a/xdg/rivendell-rdalsaconfig-sudo.desktop
+++ b/xdg/rivendell-rdalsaconfig-sudo.desktop
@@ -7,3 +7,4 @@ GenericName=Rivendell ALSA Configuration
 Exec=sudo rdalsaconfig --manage-daemons
 Icon=rivendell
 Type=Application
+StartupWMClass=rivendell

--- a/xdg/rivendell-rdalsaconfig.desktop
+++ b/xdg/rivendell-rdalsaconfig.desktop
@@ -10,3 +10,4 @@ Type=Application
 Terminal=false
 X-KDE-SubstituteUID=true
 X-KDE-Username=root
+StartupWMClass=rivendell

--- a/xdg/rivendell-rdcartslots.desktop
+++ b/xdg/rivendell-rdcartslots.desktop
@@ -8,4 +8,4 @@ Exec=rdcartslots
 Icon=rdcartslots
 Type=Application
 Terminal=false
-
+StartupWMClass=rdcartslots

--- a/xdg/rivendell-rdcastmanager.desktop
+++ b/xdg/rivendell-rdcastmanager.desktop
@@ -8,4 +8,4 @@ Exec=rdcastmanager
 Icon=rdcastmanager
 Type=Application
 Terminal=false
-
+StartupWMClass=rdcastmanager

--- a/xdg/rivendell-rdcatch.desktop
+++ b/xdg/rivendell-rdcatch.desktop
@@ -8,4 +8,4 @@ Exec=rdcatch
 Icon=rdcatch
 Type=Application
 Terminal=false
-
+StartupWMClass=rdcatch

--- a/xdg/rivendell-rddbconfig-root.desktop
+++ b/xdg/rivendell-rddbconfig-root.desktop
@@ -8,3 +8,4 @@ Exec=rddbconfig-root
 Icon=rdadmin
 Type=Application
 Terminal=false
+StartupWMClass=rdadmin

--- a/xdg/rivendell-rddbconfig-sudo.desktop
+++ b/xdg/rivendell-rddbconfig-sudo.desktop
@@ -7,3 +7,4 @@ GenericName=Rivendell Database Management
 Exec=sudo rddbconfig
 Icon=rdadmin
 Type=Application
+StartupWMClass=rdadmin

--- a/xdg/rivendell-rddbconfig.desktop
+++ b/xdg/rivendell-rddbconfig.desktop
@@ -10,3 +10,4 @@ Type=Application
 Terminal=false
 X-KDE-SubstituteUID=true
 X-KDE-Username=root
+StartupWMClass=rdadmin

--- a/xdg/rivendell-rdgpimon.desktop
+++ b/xdg/rivendell-rdgpimon.desktop
@@ -8,4 +8,4 @@ Exec=rdgpimon
 Icon=rivendell
 Type=Application
 Terminal=false
-
+StartupWMClass=rivendell

--- a/xdg/rivendell-rdlibrary.desktop
+++ b/xdg/rivendell-rdlibrary.desktop
@@ -8,4 +8,4 @@ Exec=rdlibrary
 Icon=rdlibrary
 Type=Application
 Terminal=false
-
+StartupWMClass=rdlibrary

--- a/xdg/rivendell-rdlogedit.desktop
+++ b/xdg/rivendell-rdlogedit.desktop
@@ -8,4 +8,4 @@ Exec=rdlogedit
 Icon=rdlogedit
 Type=Application
 Terminal=false
-
+StartupWMClass=rdlogedit

--- a/xdg/rivendell-rdlogin.desktop
+++ b/xdg/rivendell-rdlogin.desktop
@@ -8,4 +8,4 @@ Exec=rdlogin
 Icon=rivendell
 Type=Application
 Terminal=false
-
+StartupWMClass=rivendell

--- a/xdg/rivendell-rdlogmanager.desktop
+++ b/xdg/rivendell-rdlogmanager.desktop
@@ -8,4 +8,4 @@ Exec=rdlogmanager
 Icon=rdlogmanager
 Type=Application
 Terminal=false
-
+StartupWMClass=rdlogmanager

--- a/xdg/rivendell-rdmonitor.desktop
+++ b/xdg/rivendell-rdmonitor.desktop
@@ -8,4 +8,4 @@ Exec=rdmonitor
 Icon=rivendell
 Type=Application
 Terminal=false
-
+StartupWMClass=rivendell

--- a/xdg/rivendell-rdpanel.desktop
+++ b/xdg/rivendell-rdpanel.desktop
@@ -8,4 +8,4 @@ Exec=rdpanel
 Icon=rdpanel
 Type=Application
 Terminal=false
-
+StartupWMClass=rdpanel

--- a/xdg/rivendell-rdsoftkeys.desktop
+++ b/xdg/rivendell-rdsoftkeys.desktop
@@ -8,4 +8,4 @@ Exec=rdsoftkeys
 Icon=rivendell
 Type=Application
 Terminal=false
-
+StartupWMClass=rivendell

--- a/xdg/rivendell-rmlsend.desktop
+++ b/xdg/rivendell-rmlsend.desktop
@@ -8,3 +8,4 @@ Exec=rmlsend
 Icon=rivendell
 Type=Application
 Terminal=false
+StartupWMClass=rivendell


### PR DESCRIPTION
# Description

**Bug Fix:** Dock icons are not displayed for any Rivendell application while using Ubuntu 24.04. The generic sprocket is displayed. This is a known change in Ubuntu which requires additional configuration to be set in the .desktop files.
Reference here: https://itsfoss.com/ubuntu-app-icon-missing/

Fixes Issue #985 

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
 Manual compilation of source, ran the program and verified manually that the change was effective.

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshot After Bug Fix (rdairplay was fixed manually to start with, the others are are not fixed in the screenshot and are just a vanilla installation of Rivendell 4.3.0.
![image](https://github.com/user-attachments/assets/9e3cc282-b45c-4583-a981-a2ff4f235d83)
![image](https://github.com/user-attachments/assets/92bc5332-79e2-4118-ba84-2030df7bdb7e)
![image](https://github.com/user-attachments/assets/a1d4fa97-6c2a-4baa-aba7-fdcfe6399085)
