### PR TITLE
Avoid overzoom

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -24959,3 +24959,5 @@
 	errors.
 2025-02-28 Fred Gleason <fredg@paravelsystems.com>
 	* Incremented the package version to 4.3.0int7.
+2025-07-10 Chris Howard <chris@elfpen.com>
+	* Fix waveform display by avoiding over-zoom

--- a/lib/rdmarkerview.cpp
+++ b/lib/rdmarkerview.cpp
@@ -743,13 +743,12 @@ bool RDMarkerView::setCut(QString *err_msg,unsigned cartnum,int cutnum)
   }
 
   //
-  // Minimum Shrink Factor  - if fractional, go next size larger
+  // Minimum Shrink Factor  - if fractional, go up
   //
-  int min_shrink=d_wave_factory->energySize()/(32768);
-  if(d_wave_factory->energySize()>(min_shrink*32768)){
-    d_min_shrink_factor=min_shrink*2;
-  }else{
-    d_min_shrink_factor=min_shrink;
+  int min_shrink=(int)ceil(d_wave_factory->energySize()/(32768.0));
+  d_min_shrink_factor=1;
+  while(d_min_shrink_factor<min_shrink) {
+    d_min_shrink_factor*=2;
   }
 
   d_pad_size=64+(d_width*d_max_shrink_factor-d_wave_factory->energySize())/d_max_shrink_factor-1;

--- a/lib/rdmarkerview.cpp
+++ b/lib/rdmarkerview.cpp
@@ -794,7 +794,7 @@ void RDMarkerView::gotoEnd()
 void RDMarkerView::maxShrinkTime()
 {
   if(canShrinkTime()) {
-    SetShrinkFactor(1);
+    SetShrinkFactor(d_min_shrink_factor);
   }    
 }
 

--- a/lib/rdmarkerview.cpp
+++ b/lib/rdmarkerview.cpp
@@ -743,12 +743,13 @@ bool RDMarkerView::setCut(QString *err_msg,unsigned cartnum,int cutnum)
   }
 
   //
-  // Minimum Shrink Factor
+  // Minimum Shrink Factor  - if fractional, go next size larger
   //
   int min_shrink=d_wave_factory->energySize()/(32768);
-  d_min_shrink_factor=1;
-  while(d_min_shrink_factor<min_shrink) {
-    d_min_shrink_factor*=2;
+  if(d_wave_factory->energySize()>(min_shrink*32768)){
+    d_min_shrink_factor=min_shrink*2;
+  }else{
+    d_min_shrink_factor=min_shrink;
   }
 
   d_pad_size=64+(d_width*d_max_shrink_factor-d_wave_factory->energySize())/d_max_shrink_factor-1;


### PR DESCRIPTION
Issue  #835 

1.       maxShrinkTime() had hardwired in the most aggressive shrink, needs to be the calculated d_min_shrink_factor.
2.       In setCut(), the calculation of d_min_shrink_factor was selecting more shrink than the data could support, this was due to integer math and using a truncated integer divide.  Fix is to go to one step less shrink if there was a remainder in the integer divide.

      