### PR TITLE
rdstatus logic for local audio store

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -25056,3 +25056,6 @@
 	* Moved the 'RDAlsaCard' class from 'utils/rdalsaconfig/' to
 	'rdalsa/' to contain ALSA card quirk information.
 	* Refactored the ALSA driver in caed(8) to use 'RDAlsaCard'.
+2025-09-18 Dennis Graiani <dennis.graiani@gmail.com>
+	* Reversed logic in rdstatus to return true when local audio store
+	is mounted.

--- a/lib/rdstatus.cpp
+++ b/lib/rdstatus.cpp
@@ -45,11 +45,11 @@ bool RDAudioStoreValid(RDConfig *config)
     return false;
   }
   if(config->audioStoreMountSource().isEmpty()) {  // Audio store is local
-    ret=true;
+    ret=false;
     while(fgets(line,1024,f)!=NULL) {
       QStringList fields=QString(line).split(" ");
       if(fields.size()>=2) {
-	ret=ret&&(fields[1]!=RD_AUDIO_ROOT);
+	ret=ret||(fields[1]==RD_AUDIO_ROOT);
       }
     }
   }


### PR DESCRIPTION
Original PR:
> Unless I am confused about how it is supposed to work, the logic for rdselect/rdmonitor is reversed for a local audio store. It shows red when the local audio store is mounted. I reversed the logic in lib/rdstatus.cpp and tested it by running rdmonitor while mounting and unmounting /var/snd on my local machine, observing that the ball turned red when unmounted, and green when mounted.

Resubmitting - just cleaning up a mess I created by committing directly to v4 for this old PR.  Nothing else new here.
