### PR TITLE
use Magick++-7 or Magick++-6

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -25134,3 +25134,5 @@
 2026-03-06 Fred Gleason <fredg@paravelsystems.com>
 	* Fixed a regression in rdautorest(8) that caused a crash when
 	cleaning up the mountpoint on CentOS 7.
+2026-05-22 Dennis Graiani <dennis.graiani@gmail.com>
+	* Modified ImageMagick check to try Magick++-7 before Magick++-6.

--- a/configure.ac
+++ b/configure.ac
@@ -350,7 +350,9 @@ AC_CHECK_HEADER(soundtouch/SoundTouch.h,[],[AC_MSG_ERROR([*** SoundTouch not fou
 #
 # Check for ImageMagick
 #
-PKG_CHECK_MODULES(IMAGEMAGICK,Magick++-6.Q16,[],[AC_MSG_ERROR([*** ImageMagick 6 Magick++ binding not found ***])])
+PKG_CHECK_MODULES(IMAGEMAGICK,Magick++-7.Q16,[],[
+  PKG_CHECK_MODULES(IMAGEMAGICK,Magick++-6.Q16,[],[AC_MSG_ERROR([*** ImageMagick 6/7 Magick++ binding not found ***])])
+])
 
 #
 # Check for Python


### PR DESCRIPTION
Fixes #1016 

Tested this in v5 and v4 branches.  In both branches I am able to add images to feeds on both Bookworm (ImageMagick 6) and Trixie (ImageMagick 7)