### PR TITLE
As of Qt 6.1.0, moc has been moved to libexec instead of bin

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -25070,3 +25070,5 @@
 	* Consolidated header declarations in 'lib/rdhash.cpp'.
 2025-04-30 Fred Gleason <fredg@paravelsystems.com>
 	* Cleaned up numerous compiler warnings.
+2025-08-24 Dennis Graiani <dennis.graiani@gmail.com>
+	* Update location of 'moc' executable which changed in Qt 6.1.0

--- a/acinclude.m4
+++ b/acinclude.m4
@@ -271,7 +271,7 @@ AC_DEFUN([AQ_FIND_QT6],[AC_REQUIRE([AC_PROG_CXX])]
       qt_libs="-L "$qt_Prefix$qt_Libraries
       qt_cppflags="-I"$qt_Prefix"/"$qt_Headers
       qt_libs="-L"$qt_Prefix"/"$qt_Libraries
-      qt_moc=$qt_Prefix"/"$qt_Binaries"/moc"
+      qt_moc=$qt_Prefix"/"$qt_LibraryExecutables"/moc"
       if test -n "$QT6_MOC" ; then
         qt_moc=$QT6_MOC
       fi


### PR DESCRIPTION
See: https://code.qt.io/cgit/qt/qtreleasenotes.git/about/qt/6.1.0/release-note.txt