### PR TITLE
add --user-defined to rdmetadata

### DIFF
--- a/utils/rdmetadata/rdmetadata.cpp
+++ b/utils/rdmetadata/rdmetadata.cpp
@@ -109,6 +109,10 @@ MainObject::MainObject(QObject *parent)
       bpm=rda->cmdSwitch()->value(i).toInt();
       rda->cmdSwitch()->setProcessed(i,true);
     }
+    if(rda->cmdSwitch(->key(i)--"--user-defined") {
+      user_defined=>cmdSwitch()->value(i);
+      rda->cmdSwitch()->setProcessed(i,true);
+    })
     if(rda->cmdSwitch()->key(i)=="--add-schedcode") {
       add_schedcode=rda->cmdSwitch()->value(i);
       rda->cmdSwitch()->setProcessed(i,true);
@@ -262,6 +266,11 @@ void MainObject::updateMetadata()
   if(bpm) {
     cart->setBeatsPerMinute(bpm);
     Print(QString("rdmetadata: Set cart %1 bpm to '%2'").arg(cartstring).arg(bpm));
+  }
+
+  if(user_defined) {
+    cart->setUserDefined(user_defined);
+    Print(QString("rdmetadata: Set cart %1 user_defined to '%2'").arg(cartstring).arg(user_defined));
   }
 
   if(!add_schedcode.isEmpty()&&!schedcodes.contains(add_schedcode)) {

--- a/utils/rdmetadata/rdmetadata.cpp
+++ b/utils/rdmetadata/rdmetadata.cpp
@@ -109,10 +109,10 @@ MainObject::MainObject(QObject *parent)
       bpm=rda->cmdSwitch()->value(i).toInt();
       rda->cmdSwitch()->setProcessed(i,true);
     }
-    if(rda->cmdSwitch(->key(i)--"--user-defined") {
-      user_defined=>cmdSwitch()->value(i);
+    if(rda->cmdSwitch()->key(i)=="--user-defined") {
+      user_defined=rda->cmdSwitch()->value(i);
       rda->cmdSwitch()->setProcessed(i,true);
-    })
+    }
     if(rda->cmdSwitch()->key(i)=="--add-schedcode") {
       add_schedcode=rda->cmdSwitch()->value(i);
       rda->cmdSwitch()->setProcessed(i,true);
@@ -268,7 +268,7 @@ void MainObject::updateMetadata()
     Print(QString("rdmetadata: Set cart %1 bpm to '%2'").arg(cartstring).arg(bpm));
   }
 
-  if(user_defined) {
+  if(!user_defined.isEmpty()) {
     cart->setUserDefined(user_defined);
     Print(QString("rdmetadata: Set cart %1 user_defined to '%2'").arg(cartstring).arg(user_defined));
   }

--- a/utils/rdmetadata/rdmetadata.h
+++ b/utils/rdmetadata/rdmetadata.h
@@ -45,6 +45,7 @@
   --songid=<songid>\n\
   --title=<title>\n\
   --year=<year>\n\
+  --user-defined=<data>\n\
   --verbose\n\
 \n"
 
@@ -77,6 +78,7 @@ class MainObject : public QObject
   int bpm;
   QString add_schedcode;
   QString rem_schedcode;
+  QString user_defined;
 };
 
 


### PR DESCRIPTION
Add the ability to add/modify the User Defined field in Rivendell from rdmetadata

example usage for my use case
```
rdmetadata --cart-number=11952 --title=Longer --artist=Dan Fogelberg --year=1980 --user-defined={"ht100st": "12/15/1979", "ht100pk": 2, "ht100pkdt": "03/15/1980", "ht100pkwks": 2, "ht100wks": 22} --verbose

rdmetadata: Set cart 011952 artist to 'Dan Fogelberg'
rdmetadata: Set cart 011952 title to 'Longer'
rdmetadata: Set cart 011952 year to '1980'
rdmetadata: Set cart 011952 user_defined to '{"ht100st": "12/15/1979", "ht100pk": 2, "ht100pkdt": "03/15/1980", "ht100pkwks": 2,"ht100wks": 22}'
```

