### PR TITLE
RDLogPlay: respect segue only when next transition is segue; add RDPlayDeck::setRespectSegue() and guard segue timers

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -61,3 +61,6 @@ Chris Smowton
 
 Scott Spillers <scotts@paravelsystems.com>
    The original Icon set
+
+Chris Conkright <cconkrig@gmail.com>
+   Fixed play vs segue transition in rdairplay

--- a/ChangeLog
+++ b/ChangeLog
@@ -25056,3 +25056,7 @@
 	* Moved the 'RDAlsaCard' class from 'utils/rdalsaconfig/' to
 	'rdalsa/' to contain ALSA card quirk information.
 	* Refactored the ALSA driver in caed(8) to use 'RDAlsaCard'.
+2025-09-25 Chris Conkright <cconkrig@gmail.com>
+    * Fixed a bug in RDAirPlay where next log item with a Play transition
+	would start at the segue start marker of the previous log item.
+	

--- a/lib/rdlogplay.cpp
+++ b/lib/rdlogplay.cpp
@@ -2062,6 +2062,9 @@ bool RDLogPlay::StartEvent(int line,RDLogLine::TransType trans_type,
       rda->syslog(LOG_DEBUG,"log engine: *** position out of bounds: Line: %d  Cart: %d  Pos: %d ***",line,logline->cartNumber(),logline->playPosition());
       logline->setPlayPosition(0);
     }
+    // Respect segue markers only if the next transition is Segue; otherwise,
+    // wait for the end marker when next is Play (no overlap per manual).
+    playdeck->setRespectSegue(nextTrans(line)==RDLogLine::Segue);
     playdeck->play(logline->playPosition(),-1,-1,duck_length);
     if(logline->status()==RDLogLine::RDLogLine::Paused) {
       logline->

--- a/lib/rdplay_deck.cpp
+++ b/lib/rdplay_deck.cpp
@@ -45,6 +45,7 @@ RDPlayDeck::RDPlayDeck(RDCae *cae,int id,QObject *parent)
   play_duck_up_point=0;
   play_duck_down_state=false;
   play_fade_down_state=false;
+  play_respect_segue=true;
 
   //
   // CAE Connection
@@ -619,6 +620,12 @@ void RDPlayDeck::duckVolume(int level,int fade)
 }
 
 
+void RDPlayDeck::setRespectSegue(bool state)
+{
+  play_respect_segue=state;
+}
+
+
 void RDPlayDeck::playingData(unsigned serial)
 {
   if(serial!=play_serial) {
@@ -663,6 +670,9 @@ void RDPlayDeck::pointTimerData(int point)
 {
   switch(point) {
       case RDPlayDeck::Segue:
+        if(!play_respect_segue) {
+          return;
+        }
 	if(play_point_state[point]) {
 	  play_point_state[point]=false;
 	  rda->cae()->stopPlay(play_serial);
@@ -824,36 +834,38 @@ void RDPlayDeck::StartTimers(int offset)
   // Initialize Segue Timers
   //
   play_point_state[RDPlayDeck::Segue]=false;
-  if((play_point_value[RDPlayDeck::Segue][0]>=0)&&
-     (play_point_value[RDPlayDeck::Segue][1]>=0)&&
-     (play_point_value[RDPlayDeck::Segue][1]>
-      play_point_value[RDPlayDeck::Segue][0])) {
-    // Setup Full Segue
-    if((play_point_value[RDPlayDeck::Segue][0]-play_audio_point[0]-offset)>=0) {
-      play_point_timer[RDPlayDeck::Segue]->
-	start(scaled_point_value[RDPlayDeck::Segue][0]-scaled_audio_point[0]-
-	      offset);
-    }
-    else {
-      if((play_point_value[RDPlayDeck::Segue][1]-play_audio_point[0]-
-	  offset)>=0) {
-	play_point_state[RDPlayDeck::Segue]=true;
-	play_point_timer[RDPlayDeck::Segue]->
-	  start(scaled_point_value[RDPlayDeck::Segue][1]-scaled_audio_point[0]-
-		offset);
+  if(play_respect_segue) {
+    if((play_point_value[RDPlayDeck::Segue][0]>=0)&&
+       (play_point_value[RDPlayDeck::Segue][1]>=0)&&
+       (play_point_value[RDPlayDeck::Segue][1]>
+        play_point_value[RDPlayDeck::Segue][0])) {
+      // Setup Full Segue
+      if((play_point_value[RDPlayDeck::Segue][0]-play_audio_point[0]-offset)>=0) {
+        play_point_timer[RDPlayDeck::Segue]->
+          start(scaled_point_value[RDPlayDeck::Segue][0]-scaled_audio_point[0]-
+                offset);
+      }
+      else {
+        if((play_point_value[RDPlayDeck::Segue][1]-play_audio_point[0]-
+            offset)>=0) {
+          play_point_state[RDPlayDeck::Segue]=true;
+          play_point_timer[RDPlayDeck::Segue]->
+            start(scaled_point_value[RDPlayDeck::Segue][1]-scaled_audio_point[0]-
+                  offset);
+        }
+      }
+      if(rda->config()->padSegueOverlaps()>0) {
+        play_point_timer[RDPlayDeck::Segue]->stop();
+        play_point_timer[RDPlayDeck::Segue]->
+          start(play_point_timer[RDPlayDeck::Segue]->interval()+
+                rda->config()->padSegueOverlaps());
       }
     }
-    if(rda->config()->padSegueOverlaps()>0) {
-      play_point_timer[RDPlayDeck::Segue]->stop();
+    else {
+      // Setup "Play Style" Segue
       play_point_timer[RDPlayDeck::Segue]->
-	start(play_point_timer[RDPlayDeck::Segue]->interval()+
-	      rda->config()->padSegueOverlaps());;
+        start(scaled_audio_point[1]-scaled_audio_point[0]+100);
     }
-  }
-  else {
-    // Setup "Play Style" Segue
-    play_point_timer[RDPlayDeck::Segue]->
-      start(scaled_audio_point[1]-scaled_audio_point[0]+100);
   }
 
   //

--- a/lib/rdplay_deck.h
+++ b/lib/rdplay_deck.h
@@ -74,6 +74,7 @@ class RDPlayDeck : public QObject
   void stop(int interval,int gain=-10000);
   void duckDown(int interval);
   void duckVolume(int level,int fade);
+  void setRespectSegue(bool state);
 
  signals:
   void stateChanged(int id,RDPlayDeck::State);
@@ -146,6 +147,7 @@ class RDPlayDeck : public QObject
   int play_current_position;
   bool play_timescale_active;
   int play_timescale_speed;
+  bool play_respect_segue;
 };
 
 


### PR DESCRIPTION
### Summary

Fixes rdairplay using segue markers even when the next event’s transition is Play. Now, segue markers are honored only when the next transition is Segue per the docs/manual. This fixes a long standing bug where imaging leading into a commercial break may have segue markers set, this would chop the imaging at the segue start marker and immediately begin the break. The imaging is now allowed to play to completion (end marker) then the "Play" transition commercial break starts.

### Symptoms

When event A has segue markers and event B’s transition is Play, Event A would stop/duck at its segue-out and overlap with B. Expected: A should play to its end with no overlap per the manual/docs.

### Root Cause

RDLogPlay::StartEvent() always armed/handled segue behavior regardless of the following transition, so the deck reacted to segue markers even when the log called for a full Play (no overlap).

### What Changed

  - RDLogPlay sets the playback deck to respect segue markers only when nextTrans(line) == RDLogLine::Segue.
  - RDPlayDeck gains setRespectSegue(bool):
  - When false, it does not arm or trigger the Segue timer and ignores Segue point callbacks.
  - When true, it arms the appropriate Segue timer (full segue if markers exist; “play-style” fallback to end-of-audio if not), still honoring padSegueOverlaps.

**Files**

  - lib/rdlogplay.cpp
  - lib/rdplay_deck.h
  - lib/rdplay_deck.cpp

**Behavior and Compatibility**

  - Segue transition: unchanged, segue markers used (or fallback to end-of-audio).
  - Play transition: carts now play to their end markers (or EOF) with no early stop/overlap due to segue markers.
  - No schema or config changes. New method is internal to rdairplay.
