### PR TITLE
Add processEvents at each logevent computation to limit heartbeat timeouts (refs #987)

### DIFF
--- a/lib/rdclock.cpp
+++ b/lib/rdclock.cpp
@@ -18,6 +18,8 @@
 //   Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 //
 
+#include <QApplication>
+
 #include "rddb.h"
 #include "rdclock.h"
 #include "rdevent_line.h"
@@ -281,6 +283,7 @@ bool RDClock::generateLog(int hour,const QString &logname,
     "order by `START_TIME`";
   q=new RDSqlQuery(sql);
   while(q->next()) {
+    qApp->processEvents();
     eventline.setName(q->value(0).toString());
     eventline.load();
     eventline.setStartTime(QTime(0,0,0).addMSecs(q->value(1).toInt()).


### PR DESCRIPTION
It doesn't fix totally the issue with long event computation, but it seems to make log generation more reliable on slow machines. rdlogmanager still outputs connection timeout and restore, but does not try to log with another wrong user (userHB-) anymore. Logs generation that formerly stopped after 220 lines now completes without issue.