### PR TITLE
Fix pypad creds interpolation

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -25134,3 +25134,5 @@
 2026-03-06 Fred Gleason <fredg@paravelsystems.com>
 	* Fixed a regression in rdautorest(8) that caused a crash when
 	cleaning up the mountpoint on CentOS 7.
+2026-06-18 Florent Peyraud <florent@draceo.fr>
+	* Disable ConfigParser interpolation for database credentials

--- a/apis/pypad/api/pypad.py
+++ b/apis/pypad/api/pypad.py
@@ -817,7 +817,7 @@ class Receiver(object):
         self.__timer_callback(config)
 
     def __getDbCredentials(self):
-        config=configparser.ConfigParser()
+        config=configparser.ConfigParser(interpolation=None)
         config.read_file(open('/etc/rd.conf'))
         return (config.get('mySQL','Loginname'),config.get('mySQL','Password'),
                 config.get('mySQL','Hostname'),config.get('mySQL','Database'))


### PR DESCRIPTION
fixes #1043 
Disable config interpolation on DBCredentials method