### PR TITLE
Fix problems in RDLogEdit miscalculating 'Est. Time' in logs with SEGUE transitions

### DIFF
--- a/lib/rdcart.cpp
+++ b/lib/rdcart.cpp
@@ -1169,9 +1169,9 @@ void RDCart::updateLength(bool enforce_length,unsigned length)
     if(q->value(0).toUInt()>0) {
       if(q->value(20).toString()=="Y") {  // Evergreen?
 	evergreen_found=true;
-	evergreen_segue_len=
+	evergreen_segue_len+=
 	  GetPointerRange(q->value(1).toInt(),q->value(2).toInt());
-	evergreen_hook_len=
+	evergreen_hook_len+=
 	  GetPointerRange(q->value(13).toInt(),q->value(14).toInt());
 	evergreen_len+=q->value(0).toUInt();
 	evergreen_cuts++;
@@ -1203,9 +1203,9 @@ void RDCart::updateLength(bool enforce_length,unsigned length)
 	      }
 	    }
 	    if(q->value(16).isNull()||(q->value(16).toDateTime()<=now)) {
-	      active_segue_len=
+	      active_segue_len+=
 		GetPointerRange(q->value(1).toInt(),q->value(2).toInt());
-	      active_hook_len=
+	      active_hook_len+=
 		GetPointerRange(q->value(13).toInt(),q->value(14).toInt());
 	      active_len+=q->value(0).toUInt();
 	      active_cuts++;

--- a/lib/rdlogmodel.cpp
+++ b/lib/rdlogmodel.cpp
@@ -799,7 +799,9 @@ QTime RDLogModel::blockStartTime(int line) const
   for(int i=start_line;i<line;i++) {
     if((i<(lineCount()+1))&&((logLine(i+1)->transType()==RDLogLine::Segue))) {
       if(logLine(i)->segueStartPoint(RDLogLine::LogPointer)<0) {
-	actual_length+=100*(logLine(i)->averageSegueLength()/100);
+	//actual_length+=100*(logLine(i)->averageSegueLength()/100);
+        actual_length+=100*( (logLine(i)->forcedLength()-logLine(i)->averageSegueLength()) / 100) ;  
+
       }
       else {
 	if(logLine(i)->startPoint(RDLogLine::LogPointer)<0) {

--- a/utils/rddbmgr/check.cpp
+++ b/utils/rddbmgr/check.cpp
@@ -136,6 +136,15 @@ bool MainObject::Check(QString *err_msg)
   }
 
   //
+  // Recalculate Lengths
+  //
+  if(db_check_all) {
+    printf("Recalculating audio lengths (this may take some time)...\n");
+    RecalculateLengths();
+    printf("done.\n\n");
+  }
+
+  //
   // Validating Audio Lengths
   //
   if(db_check_all) {
@@ -686,6 +695,33 @@ void MainObject::CheckCutCounts() const
   delete q;
 }
 
+void MainObject::RecalculateLengths() const
+{
+  QString sql;
+  QSqlQuery *q;
+  unsigned c=0;
+
+  sql=QString("select ")+
+    "`NUMBER`,"+        // 00
+    "`CUT_QUANTITY`,"+  // 01
+    "`TITLE` "+         // 02
+    "from `CART`";
+  q=new QSqlQuery(sql);
+  while(q->next()) {
+	RDCart *cart=new RDCart(q->value(0).toUInt());
+        if(cart->type()==RDCart::Audio) {
+		cart->updateLength();
+	}
+	//cart->resetRotation();
+	delete cart;
+
+	c++;	
+	if (c % 1000 == 0) {
+		printf("Recalculating: %u\n", c); 
+	}
+  }
+  delete q;
+}
 
 void MainObject::CheckPendingCarts() const
 {

--- a/utils/rddbmgr/rddbmgr.h
+++ b/utils/rddbmgr/rddbmgr.h
@@ -82,6 +82,7 @@ class MainObject : public QObject
   QStringList GetCanonicalTables(int schema) const;
   void CheckLogLineIds(const QString &logname) const;
   void ValidateAudioLengths() const;
+  void RecalculateLengths() const;
   void Rehash(const QString &arg) const;
   void RehashCart(unsigned cartnum) const;
   void RehashCut(const QString &cutnum) const;


### PR DESCRIPTION
This patch resolves a bug in RDLogEdit that incorrectly calculated estimated times ("Est. Time") in logs where carts have a SEGUE type transition. There was a change in the way the AVERAGE_SEGUE_LENGTH field is calculated from version 4.1.3 to version 4.3.0, and, according to that change, a routine was placed in `rddbmgr --check` that recalculates AVERAGE_SEGUE_LENGTH in all audio records in the CART table. In addition, the calculation of "Est. Time" in rdlogmodel.cpp and a small bug in the segue's calculation in updateLength() were corrected.

More details in https://github.com/ElvishArtisan/rivendell/issues/1037#issuecomment-5391583922