### PR TITLE
RDAirPlay in spanish: Time column in logs does not show AM/PM

### DIFF
--- a/lib/rdcoreapplication.cpp
+++ b/lib/rdcoreapplication.cpp
@@ -425,7 +425,9 @@ QString RDCoreApplication::timeString(const QTime &time,bool show_secs,
     }
   }
   if(app_show_twelve_hour_time) {
-    QString time_str=time.toString(RD_TWELVE_HOUR_FORMAT);
+    //QString time_str=time.toString(RD_TWELVE_HOUR_FORMAT);
+    QLocale localeFijo(QLocale::English, QLocale::UnitedStates);
+    QString time_str=localeFijo.toString(time, RD_TWELVE_HOUR_FORMAT);
     if(!padding.isEmpty()) {
       if((time.hour()==0)||((time.hour()>=10)&&(time.hour()<13))||
 	 (time.hour()>=22)) {
@@ -486,7 +488,9 @@ QString RDCoreApplication::tenthsTimeString(const QTime &time,
 					    const QString &padding) const
 {
   if(app_show_twelve_hour_time) {
-    QString time_str=time.toString(RD_TWELVE_HOUR_TENTHS_FORMAT);
+    //QString time_str=time.toString(RD_TWELVE_HOUR_TENTHS_FORMAT);
+    QLocale localeFijo(QLocale::English, QLocale::UnitedStates);
+    QString time_str=localeFijo.toString(time, RD_TWELVE_HOUR_TENTHS_FORMAT);
     if(!padding.isEmpty()) {
       if((time.hour()==0)||((time.hour()>=10)&&(time.hour()<13))||
 	 (time.hour()>=22)) {
@@ -494,7 +498,9 @@ QString RDCoreApplication::tenthsTimeString(const QTime &time,
       }
       return padding+time_str.left(9)+" "+time_str.right(2);
     }
-    if(((time.hour()>=10)&&(time.hour()<13))||(time.hour()>=22)) {
+    //if(((time.hour()>=10)&&(time.hour()<13))||(time.hour()>=22)) {
+    if((time.hour()==0)||((time.hour()>=10)&&(time.hour()<13))||  
+         (time.hour()>=22)) {   
       return time_str.left(10)+" "+time_str.right(2);
     }
     return time_str.left(9)+" "+time_str.right(2);

--- a/rdlibrary/edit_cart.cpp
+++ b/rdlibrary/edit_cart.cpp
@@ -107,7 +107,7 @@ EditCart::EditCart(const QList<unsigned> &cartnums,QString *path,bool new_cart,
     rdcart_group_box->setGeometry(280,11,140,21);
   }
   else {
-    rdcart_group_box->setGeometry(135,38,110,21);
+    rdcart_group_box->setGeometry(135,38,140,21);
   }
   rdcart_group_model=new RDGroupListModel(false,cartnums.size()>1,false,this);
   rdcart_group_box->setModel(rdcart_group_model);


### PR DESCRIPTION
Problem: When RDAirPlay is set to Spanish (and possibly other languages) and the time format is in 12-hour mode, the "Estimated Time" column in the Main Log or Aux Logs displays "M" instead of "AM" or "PM" (for example, it displays "9:05:00 M" instead of "9:05:00 AM").

More info: https://github.com/ElvishArtisan/rivendell/issues/1049

This also fixes a problem in RDLibrary, when editing multiple carts: the group box is too small and large group names don't fit.

https://github.com/ElvishArtisan/rivendell/issues/1050

