### PR TITLE
Real-time search now feels a lot faster in RDAirPlay, RDLibrary, etc.

### DIFF
--- a/lib/rdcartfilter.cpp
+++ b/lib/rdcartfilter.cpp
@@ -179,6 +179,11 @@ RDCartFilter::RDCartFilter(bool show_drag_box,bool user_is_admin,
     d_showmatches_check->setChecked(rda->libraryConf()->searchLimited());
     break;
   }
+
+  d_last_search_time = QDateTime::currentMSecsSinceEpoch();
+  search_filter_timer=new QTimer(this);
+  connect(search_filter_timer,SIGNAL(timeout()),this,SLOT(searchClickedData()));
+  search_filter_timer->start(100);
 }
 
 
@@ -441,6 +446,7 @@ void RDCartFilter::changeUser()
 
 void RDCartFilter::filterChangedData(const QString &str)
 {
+  d_last_search_time = QDateTime::currentMSecsSinceEpoch();  
   d_search_button->setEnabled(true);
   if(rda->station()->filterMode()!=RDStation::FilterSynchronous) {
     return;
@@ -464,6 +470,10 @@ void RDCartFilter::setMatchCount(int matches)
 void RDCartFilter::searchClickedData()
 {
 
+  qint64 now = QDateTime::currentMSecsSinceEpoch();
+  if (now-d_last_search_time<750)
+    return;
+  d_last_search_time = now;
   d_search_button->setDisabled(true);
   if(d_filter_edit->text().isEmpty()) {
     d_clear_button->setDisabled(true);
@@ -857,17 +867,31 @@ void RDCartFilter::UpdateModel()
 QString RDCartFilter::ClauseSql(const QString &clause,bool incl_cuts)
 {
   QString search=RDEscapeString(clause);
-  QString sql=QString("(`CART`.`TITLE` like '%")+search+"%')||"+
-    "(`CART`.`ARTIST` like '%"+search+"%')||"+
-    "(`CART`.`CLIENT` like '%"+search+"%')||"+
-    "(`CART`.`AGENCY` like '%"+search+"%')||"+
-    "(`CART`.`ALBUM` like '%"+search+"%')||"+
-    "(`CART`.`LABEL` like '%"+search+"%')||"+
-    "(`CART`.`PUBLISHER` like '%"+search+"%')||"+
-    "(`CART`.`COMPOSER` like '%"+search+"%')||"+
-    "(`CART`.`CONDUCTOR` like '%"+search+"%')||"+
-    "(`CART`.`SONG_ID` like '%"+search+"%')||"+
-    "(`CART`.`USER_DEFINED` like '%"+search+"%')||";
+  QString sql="";
+  QStringList words = search.split(' ');
+
+  bool first=false;
+  foreach (const QString &word, words) {
+    if (first)
+        sql=sql+QString(" AND ");
+
+    sql=sql+QString(" CONCAT(`CART`.`TITLE`,")+
+                            " `CART`.`ARTIST`,"+
+                            " `CART`.`AGENCY`,"+
+                            " `CART`.`ALBUM`,"+
+                            " `CART`.`LABEL`,"+
+                            " `CART`.`PUBLISHER`,"+
+                            " `CART`.`COMPOSER`,"+
+                            " `CART`.`CONDUCTOR`,"+
+                            " `CART`.`SONG_ID`,"+
+                            " `CART`.`USER_DEFINED`"+
+                            ") like \"%" +word+ "%\" ";
+    first=true;
+  }
+
+  if (sql!="")
+    sql=" ("+sql+") ||";
+
   if(incl_cuts) {
     sql+=QString("(`CUTS`.`ISCI` like '%")+search+"%')||"+
       "(`CUTS`.`ISRC` like '%"+search+"%')||"+

--- a/lib/rdcartfilter.h
+++ b/lib/rdcartfilter.h
@@ -127,6 +127,8 @@ class RDCartFilter : public RDWidget
   QString d_service;
   QString d_model_filter_sql;
   int d_model_cart_limit;
+  QTimer *search_filter_timer;
+  qint64 d_last_search_time;
 };
 
 


### PR DESCRIPTION
This patch optimizes real-time search performance across RDAirPlay, RDLibrary, and other applications, reducing SQL query load and improving responsiveness. Specifically, when opening the search window to find tracks by artist or title in RDAirPlay, the application now waits 750 ms after each keystroke before executing a query. If you type continuously (such as the name of an artist or song), SQL queries are deferred until you stop typing and the 750 ms delay has elapsed.

With this patch, typing "michael jackson" quickly (with less than 750 ms between keystrokes) triggers a single SQL query only after the user stops typing. Previously, Rivendell executed 15 separate SQL queries—one for every character typed. At least on my system with 30,000 carts, this previously made the search feel sluggish.

The SQL query now splits search phrases into individual words for independent matching. Previously, searching for "Anniversary song" required an exact string match; now, it also matches items like "Song for my Anniversary" where both words are present.